### PR TITLE
When sorting RowHeader, sorting the CellItems too

### DIFF
--- a/tableview/src/main/java/com/evrencoskun/tableview/ITableView.java
+++ b/tableview/src/main/java/com/evrencoskun/tableview/ITableView.java
@@ -25,6 +25,7 @@ import android.view.ViewGroup;
 import com.evrencoskun.tableview.adapter.AbstractTableAdapter;
 import com.evrencoskun.tableview.adapter.recyclerview.CellRecyclerView;
 import com.evrencoskun.tableview.filter.Filter;
+import com.evrencoskun.tableview.handler.ColumnSortHandler;
 import com.evrencoskun.tableview.handler.FilterHandler;
 import com.evrencoskun.tableview.handler.SelectionHandler;
 import com.evrencoskun.tableview.layoutmanager.CellLayoutManager;
@@ -69,6 +70,8 @@ public interface ITableView {
     ITableViewListener getTableViewListener();
 
     SelectionHandler getSelectionHandler();
+    
+    ColumnSortHandler getColumnSortHandler();
 
     DividerItemDecoration getHorizontalItemDecoration();
 

--- a/tableview/src/main/java/com/evrencoskun/tableview/TableView.java
+++ b/tableview/src/main/java/com/evrencoskun/tableview/TableView.java
@@ -567,6 +567,11 @@ public class TableView extends FrameLayout implements ITableView {
     }
 
     @Override
+    public ColumnSortHandler getColumnSortHandler() {
+        return mColumnSortHandler;
+    }
+
+    @Override
     public DividerItemDecoration getHorizontalItemDecoration() {
         if (mHorizontalItemDecoration == null) {
             mHorizontalItemDecoration = createItemDecoration(DividerItemDecoration.HORIZONTAL);

--- a/tableview/src/main/java/com/evrencoskun/tableview/handler/ColumnSortHandler.java
+++ b/tableview/src/main/java/com/evrencoskun/tableview/handler/ColumnSortHandler.java
@@ -46,6 +46,16 @@ public class ColumnSortHandler {
     private RowHeaderRecyclerViewAdapter mRowHeaderRecyclerViewAdapter;
     private ColumnHeaderRecyclerViewAdapter mColumnHeaderRecyclerViewAdapter;
 
+    private boolean mEnableAnimation = true;
+
+    public boolean isEnableAnimation() {
+        return mEnableAnimation;
+    }
+
+    public void setEnableAnimation(boolean mEnableAnimation) {
+        this.mEnableAnimation = mEnableAnimation;
+    }
+
     public ColumnSortHandler(ITableView tableView) {
         this.mCellRecyclerViewAdapter = (CellRecyclerViewAdapter) tableView.getCellRecyclerView()
                 .getAdapter();
@@ -119,34 +129,35 @@ public class ColumnSortHandler {
                            List<ISortableModel> newRowHeader,
                            List<List<ISortableModel>> newColumnItems) {
 
-        // Find the differences between old cell items and new items.
-        final RowHeaderSortCallback diffCallback = new RowHeaderSortCallback(oldRowHeader, newRowHeader);
-
-        final DiffUtil.DiffResult diffResult = DiffUtil.calculateDiff(diffCallback);
-
         // Set new items without calling notifyCellDataSetChanged method of CellRecyclerViewAdapter
-        mRowHeaderRecyclerViewAdapter.setItems(newRowHeader, false);
-        mCellRecyclerViewAdapter.setItems(newColumnItems, false);
+        mRowHeaderRecyclerViewAdapter.setItems(newRowHeader, !mEnableAnimation);
+        mCellRecyclerViewAdapter.setItems(newColumnItems, !mEnableAnimation);
 
-        diffResult.dispatchUpdatesTo(mRowHeaderRecyclerViewAdapter);
-        diffResult.dispatchUpdatesTo(mCellRecyclerViewAdapter);
+        if(mEnableAnimation) {
+            // Find the differences between old cell items and new items.
+            final RowHeaderSortCallback diffCallback = new RowHeaderSortCallback(oldRowHeader, newRowHeader);
+            final DiffUtil.DiffResult diffResult = DiffUtil.calculateDiff(diffCallback);
+
+            diffResult.dispatchUpdatesTo(mRowHeaderRecyclerViewAdapter);
+            diffResult.dispatchUpdatesTo(mCellRecyclerViewAdapter);
+        }
     }
 
     private void swapItems(List<List<ISortableModel>> oldItems, List<List<ISortableModel>>
             newItems, int column, List<ISortableModel> newRowHeader) {
 
-        // Find the differences between old cell items and new items.
-        final ColumnSortCallback diffCallback = new ColumnSortCallback(oldItems, newItems, column);
-
-        final DiffUtil.DiffResult diffResult = DiffUtil.calculateDiff(diffCallback);
-
         // Set new items without calling notifyCellDataSetChanged method of CellRecyclerViewAdapter
-        mCellRecyclerViewAdapter.setItems(newItems, false);
-        mRowHeaderRecyclerViewAdapter.setItems(newRowHeader, false);
+        mCellRecyclerViewAdapter.setItems(newItems, !mEnableAnimation);
+        mRowHeaderRecyclerViewAdapter.setItems(newRowHeader, !mEnableAnimation);
 
-        diffResult.dispatchUpdatesTo(mCellRecyclerViewAdapter);
-        diffResult.dispatchUpdatesTo(mRowHeaderRecyclerViewAdapter);
+        if(mEnableAnimation) {
+            // Find the differences between old cell items and new items.
+            final ColumnSortCallback diffCallback = new ColumnSortCallback(oldItems, newItems, column);
+            final DiffUtil.DiffResult diffResult = DiffUtil.calculateDiff(diffCallback);
 
+            diffResult.dispatchUpdatesTo(mCellRecyclerViewAdapter);
+            diffResult.dispatchUpdatesTo(mRowHeaderRecyclerViewAdapter);
+        }
     }
 
     public void swapItems(List<List<ISortableModel>> newItems, int column) {
@@ -154,16 +165,17 @@ public class ColumnSortHandler {
         List<List<ISortableModel>> oldItems = (List<List<ISortableModel>>)
                 mCellRecyclerViewAdapter.getItems();
 
-        // Find the differences between old cell items and new items.
-        final ColumnSortCallback diffCallback = new ColumnSortCallback(oldItems, newItems, column);
-
-        final DiffUtil.DiffResult diffResult = DiffUtil.calculateDiff(diffCallback);
-
         // Set new items without calling notifyCellDataSetChanged method of CellRecyclerViewAdapter
-        mCellRecyclerViewAdapter.setItems(newItems, false);
+        mCellRecyclerViewAdapter.setItems(newItems, !mEnableAnimation);
 
-        diffResult.dispatchUpdatesTo(mCellRecyclerViewAdapter);
-        diffResult.dispatchUpdatesTo(mRowHeaderRecyclerViewAdapter);
+        if(mEnableAnimation) {
+            // Find the differences between old cell items and new items.
+            final ColumnSortCallback diffCallback = new ColumnSortCallback(oldItems, newItems, column);
+            final DiffUtil.DiffResult diffResult = DiffUtil.calculateDiff(diffCallback);
+
+            diffResult.dispatchUpdatesTo(mCellRecyclerViewAdapter);
+            diffResult.dispatchUpdatesTo(mRowHeaderRecyclerViewAdapter);
+        }
 
     }
 

--- a/tableview/src/main/java/com/evrencoskun/tableview/sort/ColumnForRowHeaderSortComparator.java
+++ b/tableview/src/main/java/com/evrencoskun/tableview/sort/ColumnForRowHeaderSortComparator.java
@@ -22,7 +22,10 @@ public class ColumnForRowHeaderSortComparator implements Comparator {
     private SortState mRortState;
     private ColumnSortComparator mColumnSortComparator;
 
-    public ColumnForRowHeaderSortComparator(List<ISortableModel> rowHeader, List<List<ISortableModel>> referenceList, int column, SortState sortState) {
+    public ColumnForRowHeaderSortComparator(List<ISortableModel> rowHeader,
+                                            List<List<ISortableModel>> referenceList,
+                                            int column,
+                                            SortState sortState) {
         this.mRowHeaderList = rowHeader;
         this.mReferenceList = referenceList;
         this.column = column;

--- a/tableview/src/main/java/com/evrencoskun/tableview/sort/RowHeaderForCellSortComparator.java
+++ b/tableview/src/main/java/com/evrencoskun/tableview/sort/RowHeaderForCellSortComparator.java
@@ -1,0 +1,37 @@
+package com.evrencoskun.tableview.sort;
+
+import java.util.Comparator;
+import java.util.List;
+
+/**
+ * Created by cedricferry on 14/2/18.
+ */
+
+public class RowHeaderForCellSortComparator implements Comparator {
+
+    private List<ISortableModel> mReferenceList;
+    private List<List<ISortableModel>> mColumnList;
+
+    private SortState mRortState;
+    private RowHeaderSortComparator mRowHeaderSortComparator;
+
+    public RowHeaderForCellSortComparator(List<ISortableModel> referenceList,
+                                          List<List<ISortableModel>> columnList,
+                                          SortState sortState) {
+        this.mReferenceList = referenceList;
+        this.mColumnList = columnList;
+        this.mRortState = sortState;
+        this.mRowHeaderSortComparator = new RowHeaderSortComparator(sortState);
+    }
+
+    @Override
+    public int compare(Object o, Object t1) {
+        Object o1 = mReferenceList.get(this.mColumnList.indexOf(o)).getContent();
+        Object o2 = mReferenceList.get(this.mColumnList.indexOf(t1)).getContent();
+        if (mRortState == SortState.DESCENDING) {
+            return mRowHeaderSortComparator.compareContent(o2, o1);
+        } else {
+            return mRowHeaderSortComparator.compareContent(o1, o2);
+        }
+    }
+}


### PR DESCRIPTION
it was a missing part of the work on sorting.
In order to keep the dataset up-to-date, the cells has to be sorted too, when rowheaders are sorted. (just like we do when sort by column, we sort the rowheaders, to keep everything aligned)

I also added an option to disable DiffUtils animation