### PR TITLE
Fixes #115

### DIFF
--- a/tableview/src/main/java/com/evrencoskun/tableview/ITableView.java
+++ b/tableview/src/main/java/com/evrencoskun/tableview/ITableView.java
@@ -118,6 +118,8 @@ public interface ITableView {
 
     int getUnSelectedColor();
 
+    int getSeparatorColor();
+
     void sortColumn(int columnPosition, SortState sortState);
 
     void sortRowHeader(SortState sortState);

--- a/tableview/src/main/java/com/evrencoskun/tableview/TableView.java
+++ b/tableview/src/main/java/com/evrencoskun/tableview/TableView.java
@@ -641,6 +641,16 @@ public class TableView extends FrameLayout implements ITableView {
         return mSelectedColor;
     }
 
+    public void setSeparatorColor(@ColorInt int mSeparatorColor) {
+        this.mSeparatorColor = mSeparatorColor;
+    }
+
+    @Override
+    public @ColorInt
+    int getSeparatorColor() {
+        return mSeparatorColor;
+    }
+
     /**
      * This method helps to change default unselected color programmatically.
      *


### PR DESCRIPTION
Adds the ability to programmatically set the separator color of a
TableView. For the sake of consistency, I alse added getSeparatorColor()
to ITableView, as well as its implementation.

This commit fixes #115 