### PR TITLE
Dont require extra casting

### DIFF
--- a/tableview/src/main/java/com/evrencoskun/tableview/adapter/ITableAdapter.java
+++ b/tableview/src/main/java/com/evrencoskun/tableview/adapter/ITableAdapter.java
@@ -27,7 +27,7 @@ import com.evrencoskun.tableview.adapter.recyclerview.holder.AbstractViewHolder;
  * Created by evrencoskun on 10/06/2017.
  */
 
-public interface ITableAdapter {
+public interface ITableAdapter<CH, RH, C> {
 
     int getColumnHeaderItemViewType(int position);
 
@@ -39,17 +39,17 @@ public interface ITableAdapter {
 
     AbstractViewHolder onCreateCellViewHolder(ViewGroup parent, int viewType);
 
-    void onBindCellViewHolder(AbstractViewHolder holder, Object cellItemModel, int
+    void onBindCellViewHolder(AbstractViewHolder holder, C cellItemModel, int
             columnPosition, int rowPosition);
 
     AbstractViewHolder onCreateColumnHeaderViewHolder(ViewGroup parent, int viewType);
 
-    void onBindColumnHeaderViewHolder(AbstractViewHolder holder, Object columnHeaderItemModel,
+    void onBindColumnHeaderViewHolder(AbstractViewHolder holder, CH columnHeaderItemModel,
                                       int columnPosition);
 
     AbstractViewHolder onCreateRowHeaderViewHolder(ViewGroup parent, int viewType);
 
-    void onBindRowHeaderViewHolder(AbstractViewHolder holder, Object rowHeaderItemModel, int
+    void onBindRowHeaderViewHolder(AbstractViewHolder holder, RH rowHeaderItemModel, int
             rowPosition);
 
     View onCreateCornerView();


### PR DESCRIPTION
This change is backwards compatible due to previously using `Object`.

For future, developers will implements a nicer interface

```java
public class SimpleTableAdapter extends AbstractTableAdapter<ColumnHeader, RowHeader, Cell> {
    @Override
    public void onBindColumnHeaderViewHolder(AbstractViewHolder holder, ColumnHeader columnHeaderItemModel, int columnPosition) {

    }

    @Override
    public void onBindRowHeaderViewHolder(AbstractViewHolder holder, RowHeader rowHeaderItemModel, int rowPosition) {

    }

    @Override
    public void onBindCellViewHolder(AbstractViewHolder holder, Cell cellItemModel, int columnPosition, int rowPosition) {

    }
}
```