### PR TITLE
Invalidate cache when changing dataset

### DIFF
--- a/tableview/src/main/java/com/evrencoskun/tableview/adapter/AbstractTableAdapter.java
+++ b/tableview/src/main/java/com/evrencoskun/tableview/adapter/AbstractTableAdapter.java
@@ -81,7 +81,7 @@ public abstract class AbstractTableAdapter<CH, RH, C> implements ITableAdapter {
         }
 
         mColumnHeaderItems = columnHeaderItems;
-
+        mTableView.getColumnHeaderLayoutManager().clearCache();
         // Set the items to the adapter
         mColumnHeaderRecyclerViewAdapter.setItems(mColumnHeaderItems);
         dispatchColumnHeaderDataSetChangesToListeners(columnHeaderItems);
@@ -105,7 +105,7 @@ public abstract class AbstractTableAdapter<CH, RH, C> implements ITableAdapter {
         }
 
         mCellItems = cellItems;
-
+        mTableView.getCellLayoutManager().clearCache();
         // Set the items to the adapter
         mCellRecyclerViewAdapter.setItems(mCellItems);
         dispatchCellDataSetChangesToListeners(mCellItems);

--- a/tableview/src/main/java/com/evrencoskun/tableview/adapter/AbstractTableAdapter.java
+++ b/tableview/src/main/java/com/evrencoskun/tableview/adapter/AbstractTableAdapter.java
@@ -81,7 +81,9 @@ public abstract class AbstractTableAdapter<CH, RH, C> implements ITableAdapter {
         }
 
         mColumnHeaderItems = columnHeaderItems;
-        mTableView.getColumnHeaderLayoutManager().clearCache();
+        // Invalidate the cached widths for letting the view measure the cells width
+        // from scratch.
+        mTableView.getColumnHeaderLayoutManager().clearCachedWidths();
         // Set the items to the adapter
         mColumnHeaderRecyclerViewAdapter.setItems(mColumnHeaderItems);
         dispatchColumnHeaderDataSetChangesToListeners(columnHeaderItems);
@@ -105,7 +107,9 @@ public abstract class AbstractTableAdapter<CH, RH, C> implements ITableAdapter {
         }
 
         mCellItems = cellItems;
-        mTableView.getCellLayoutManager().clearCache();
+        // Invalidate the cached widths for letting the view measure the cells width
+        // from scratch.
+        mTableView.getCellLayoutManager().clearCachedWidths();
         // Set the items to the adapter
         mCellRecyclerViewAdapter.setItems(mCellItems);
         dispatchCellDataSetChangesToListeners(mCellItems);

--- a/tableview/src/main/java/com/evrencoskun/tableview/layoutmanager/CellLayoutManager.java
+++ b/tableview/src/main/java/com/evrencoskun/tableview/layoutmanager/CellLayoutManager.java
@@ -528,7 +528,10 @@ public class CellLayoutManager extends LinearLayoutManager {
         return -1;
     }
 
-    public void clearCache() {
+    /**
+     * Clears the widths which have been calculated and reused.
+     */
+    public void clearCachedWidths() {
         mCachedWidthList.clear();
     }
 

--- a/tableview/src/main/java/com/evrencoskun/tableview/layoutmanager/CellLayoutManager.java
+++ b/tableview/src/main/java/com/evrencoskun/tableview/layoutmanager/CellLayoutManager.java
@@ -528,6 +528,10 @@ public class CellLayoutManager extends LinearLayoutManager {
         return -1;
     }
 
+    public void clearCache() {
+        mCachedWidthList.clear();
+    }
+
     public CellRecyclerView[] getVisibleCellRowRecyclerViews() {
         int length = findLastVisibleItemPosition() - findFirstVisibleItemPosition() + 1;
         CellRecyclerView[] recyclerViews = new CellRecyclerView[length];

--- a/tableview/src/main/java/com/evrencoskun/tableview/layoutmanager/ColumnHeaderLayoutManager.java
+++ b/tableview/src/main/java/com/evrencoskun/tableview/layoutmanager/ColumnHeaderLayoutManager.java
@@ -100,7 +100,10 @@ public class ColumnHeaderLayoutManager extends LinearLayoutManager {
         mCachedWidthList.remove(position);
     }
 
-    public void clearCache() {
+    /**
+     * Clears the widths which have been calculated and reused.
+     */
+    public void clearCachedWidths() {
         mCachedWidthList.clear();
     }
 

--- a/tableview/src/main/java/com/evrencoskun/tableview/layoutmanager/ColumnHeaderLayoutManager.java
+++ b/tableview/src/main/java/com/evrencoskun/tableview/layoutmanager/ColumnHeaderLayoutManager.java
@@ -100,6 +100,9 @@ public class ColumnHeaderLayoutManager extends LinearLayoutManager {
         mCachedWidthList.remove(position);
     }
 
+    public void clearCache() {
+        mCachedWidthList.clear();
+    }
 
     public void customRequestLayout() {
         int left = getFirstItemLeft();


### PR DESCRIPTION
This pull request add the widths cache clearing when calling `setAllItems(List<CH>, List<RH>, List<List<C>>)` as mentioned in issue [#167](https://github.com/evrencoskun/TableView/issues/167)