### PR TITLE
Fix single click on cells

### DIFF
--- a/tableview/src/main/java/com/evrencoskun/tableview/listener/itemclick/AbstractItemClickListener.java
+++ b/tableview/src/main/java/com/evrencoskun/tableview/listener/itemclick/AbstractItemClickListener.java
@@ -60,7 +60,7 @@ public abstract class AbstractItemClickListener implements RecyclerView.OnItemTo
             @Override
             public boolean onDown(MotionEvent e) {
                 start = e;
-                return false;
+                return true;
             }
 
             @Override

--- a/tableview/src/main/java/com/evrencoskun/tableview/listener/itemclick/CellRecyclerViewItemClickListener.java
+++ b/tableview/src/main/java/com/evrencoskun/tableview/listener/itemclick/CellRecyclerViewItemClickListener.java
@@ -45,7 +45,7 @@ public class CellRecyclerViewItemClickListener extends AbstractItemClickListener
         // Get interacted view from x,y coordinate.
         View childView = view.findChildViewUnder(e.getX(), e.getY());
 
-        if (childView != null && mGestureDetector.onTouchEvent(e)) {
+        if (childView != null) {
             // Find the view holder
             AbstractViewHolder holder = (AbstractViewHolder) mRecyclerView.getChildViewHolder
                     (childView);
@@ -72,6 +72,7 @@ public class CellRecyclerViewItemClickListener extends AbstractItemClickListener
         return false;
     }
 
+    @Override
     protected void longPressAction(MotionEvent e) {
         // Consume the action for the time when either the cell row recyclerView or
         // the cell recyclerView is scrolling.

--- a/tableview/src/main/java/com/evrencoskun/tableview/listener/itemclick/ColumnHeaderRecyclerViewItemClickListener.java
+++ b/tableview/src/main/java/com/evrencoskun/tableview/listener/itemclick/ColumnHeaderRecyclerViewItemClickListener.java
@@ -42,7 +42,7 @@ public class ColumnHeaderRecyclerViewItemClickListener extends AbstractItemClick
         // Get interacted view from x,y coordinate.
         View childView = view.findChildViewUnder(e.getX(), e.getY());
 
-        if (childView != null && mGestureDetector.onTouchEvent(e)) {
+        if (childView != null) {
             // Find the view holder
             AbstractViewHolder holder = (AbstractViewHolder) mRecyclerView.getChildViewHolder
                     (childView);
@@ -64,6 +64,7 @@ public class ColumnHeaderRecyclerViewItemClickListener extends AbstractItemClick
         return false;
     }
 
+    @Override
     protected void longPressAction(MotionEvent e) {
         // Consume the action for the time when the recyclerView is scrolling.
         if (mRecyclerView.getScrollState() != RecyclerView.SCROLL_STATE_IDLE) {

--- a/tableview/src/main/java/com/evrencoskun/tableview/listener/itemclick/RowHeaderRecyclerViewItemClickListener.java
+++ b/tableview/src/main/java/com/evrencoskun/tableview/listener/itemclick/RowHeaderRecyclerViewItemClickListener.java
@@ -41,7 +41,7 @@ public class RowHeaderRecyclerViewItemClickListener extends AbstractItemClickLis
         // Get interacted view from x,y coordinate.
         View childView = view.findChildViewUnder(e.getX(), e.getY());
 
-        if (childView != null && mGestureDetector.onTouchEvent(e)) {
+        if (childView != null) {
             // Find the view holder
             AbstractViewHolder holder = (AbstractViewHolder) mRecyclerView.getChildViewHolder
                     (childView);
@@ -62,6 +62,7 @@ public class RowHeaderRecyclerViewItemClickListener extends AbstractItemClickLis
         return false;
     }
 
+    @Override
     protected void longPressAction(MotionEvent e) {
         // Consume the action for the time when the recyclerView is scrolling.
         if (mRecyclerView.getScrollState() != RecyclerView.SCROLL_STATE_IDLE) {


### PR DESCRIPTION
This PR fixes an issue which caused the single click listener not to being triggered.
The problem appears when clicking onto a cell (no matter if header or not). 

It can be reproduced by launching the example project and single-clicking onto a cell: a Toast will appear incorrectly indicating that a long click has been performed.

The checks using `mGestureDetector.onTouchEvent(e)` aren't necessary into `AbstractItemClickListener` subclasses because the methods in which are used are called during a `mGestureDetector.onTouchEvent(e)` invocation, started from the `onInterceptTouchEvent` method of the `AbstractItemClickListener`.