### PR TITLE
Allow click inside cells. Configurable by xml attrs.

### DIFF
--- a/tableview/src/main/java/com/evrencoskun/tableview/ITableView.java
+++ b/tableview/src/main/java/com/evrencoskun/tableview/ITableView.java
@@ -55,6 +55,8 @@ public interface ITableView {
 
     boolean isShowVerticalSeparators();
 
+    boolean isAllowClickInsideCell();
+
     boolean isSortable();
 
     @NonNull

--- a/tableview/src/main/java/com/evrencoskun/tableview/TableView.java
+++ b/tableview/src/main/java/com/evrencoskun/tableview/TableView.java
@@ -112,6 +112,9 @@ public class TableView extends FrameLayout implements ITableView {
     private boolean mIgnoreSelectionColors;
     private boolean mShowHorizontalSeparators = true;
     private boolean mShowVerticalSeparators = true;
+    private boolean mAllowClickInsideCell = false;
+    private boolean mAllowClickInsideRowHeader = false;
+    private boolean mAllowClickInsideColumnHeader = false;
     private boolean mIsSortable;
 
     public TableView(@NonNull Context context) {
@@ -174,6 +177,12 @@ public class TableView extends FrameLayout implements ITableView {
                     mShowVerticalSeparators);
             mShowHorizontalSeparators = a.getBoolean(R.styleable
                     .TableView_show_horizontal_separator, mShowHorizontalSeparators);
+            mAllowClickInsideCell = a.getBoolean(R.styleable.TableView_allow_click_inside_cell,
+                    mAllowClickInsideCell);
+            mAllowClickInsideRowHeader = a.getBoolean(R.styleable.TableView_allow_click_inside_row_header,
+                    mAllowClickInsideRowHeader);
+            mAllowClickInsideColumnHeader = a.getBoolean(R.styleable.TableView_allow_click_inside_column_header,
+                    mAllowClickInsideColumnHeader);
 
         } finally {
             a.recycle();
@@ -220,15 +229,21 @@ public class TableView extends FrameLayout implements ITableView {
 
         // --- Listeners to help item clicks ---
         // Create item click listeners
-        ColumnHeaderRecyclerViewItemClickListener columnHeaderRecyclerViewItemClickListener = new
-                ColumnHeaderRecyclerViewItemClickListener(mColumnHeaderRecyclerView, this);
-        RowHeaderRecyclerViewItemClickListener rowHeaderRecyclerViewItemClickListener = new RowHeaderRecyclerViewItemClickListener
-                (mRowHeaderRecyclerView, this);
 
-        // Add item click listeners for both column header & row header recyclerView
-        mColumnHeaderRecyclerView.addOnItemTouchListener
-                (columnHeaderRecyclerViewItemClickListener);
-        mRowHeaderRecyclerView.addOnItemTouchListener(rowHeaderRecyclerViewItemClickListener);
+        // Add item click listener for column header recyclerView
+        if(!mAllowClickInsideColumnHeader){
+            ColumnHeaderRecyclerViewItemClickListener columnHeaderRecyclerViewItemClickListener = new
+                    ColumnHeaderRecyclerViewItemClickListener(mColumnHeaderRecyclerView, this);
+            mColumnHeaderRecyclerView.addOnItemTouchListener
+                    (columnHeaderRecyclerViewItemClickListener);
+        }
+
+        // Add item click listener for row header recyclerView
+        if(!mAllowClickInsideRowHeader) {
+            RowHeaderRecyclerViewItemClickListener rowHeaderRecyclerViewItemClickListener = new RowHeaderRecyclerViewItemClickListener
+                    (mRowHeaderRecyclerView, this);
+            mRowHeaderRecyclerView.addOnItemTouchListener(rowHeaderRecyclerViewItemClickListener);
+        }
 
 
         // Add Layout change listener both of Column Header  & Cell recyclerView to detect
@@ -352,6 +367,11 @@ public class TableView extends FrameLayout implements ITableView {
     @Override
     public boolean isShowHorizontalSeparators() {
         return mShowHorizontalSeparators;
+    }
+
+    @Override
+    public boolean isAllowClickInsideCell(){
+        return mAllowClickInsideCell;
     }
 
     @Override

--- a/tableview/src/main/java/com/evrencoskun/tableview/adapter/recyclerview/CellRecyclerViewAdapter.java
+++ b/tableview/src/main/java/com/evrencoskun/tableview/adapter/recyclerview/CellRecyclerViewAdapter.java
@@ -83,8 +83,10 @@ public class CellRecyclerViewAdapter<C> extends AbstractRecyclerViewAdapter<C> {
         recyclerView.addOnItemTouchListener(mTableView.getHorizontalRecyclerViewListener());
 
         // Add Item click listener for cell views
-        recyclerView.addOnItemTouchListener(new CellRecyclerViewItemClickListener(recyclerView,
-                mTableView));
+        if(!mTableView.isAllowClickInsideCell()) {
+            recyclerView.addOnItemTouchListener(new CellRecyclerViewItemClickListener(recyclerView,
+                    mTableView));
+        }
 
         // Set the Column layout manager that helps the fit width of the cell and column header
         // and it also helps to locate the scroll position of the horizontal recyclerView

--- a/tableview/src/main/res/values/attrs.xml
+++ b/tableview/src/main/res/values/attrs.xml
@@ -26,5 +26,8 @@
         <attr name="separator_color" format="color"/>
         <attr name="show_vertical_separator" format="boolean"/>
         <attr name="show_horizontal_separator" format="boolean"/>
+        <attr name="allow_click_inside_cell" format="boolean" />
+        <attr name="allow_click_inside_row_header" format="boolean" />
+        <attr name="allow_click_inside_column_header" format="boolean" />
     </declare-styleable>
 </resources>


### PR DESCRIPTION
- Allow click inside cells by no adding default item click listeners.
- When enabling clicking inside cells, `ITableViewListener` will not be called.
- Configurable for cells, row headers and column headers.
- When clicking inside cells enabled your can add your own click listeners to views inside cells.
