### PR TITLE
Fix #266 - fix cell and column width computation

### DIFF
--- a/tableview/src/main/java/com/evrencoskun/tableview/layoutmanager/CellLayoutManager.java
+++ b/tableview/src/main/java/com/evrencoskun/tableview/layoutmanager/CellLayoutManager.java
@@ -513,7 +513,7 @@ public class CellLayoutManager extends LinearLayoutManager {
     public int getCacheWidth(int row, int column) {
         SparseIntArray cellRowCaches = mCachedWidthList.get(row);
         if (cellRowCaches != null) {
-            return cellRowCaches.get(column);
+            return cellRowCaches.get(column, -1);
         }
         return -1;
     }

--- a/tableview/src/main/java/com/evrencoskun/tableview/layoutmanager/ColumnHeaderLayoutManager.java
+++ b/tableview/src/main/java/com/evrencoskun/tableview/layoutmanager/ColumnHeaderLayoutManager.java
@@ -83,7 +83,7 @@ public class ColumnHeaderLayoutManager extends LinearLayoutManager {
     }
 
     public int getCacheWidth(int position) {
-        return mCachedWidthList.get(position);
+        return mCachedWidthList.get(position, -1);
     }
 
     public int getFirstItemLeft() {

--- a/tableview/src/main/java/com/evrencoskun/tableview/listener/itemclick/CellRecyclerViewItemClickListener.java
+++ b/tableview/src/main/java/com/evrencoskun/tableview/listener/itemclick/CellRecyclerViewItemClickListener.java
@@ -83,7 +83,6 @@ public class CellRecyclerViewItemClickListener extends AbstractItemClickListener
         View child = mRecyclerView.findChildViewUnder(e.getX(), e.getY());
 
         if (child != null) {
-            getTableViewListener();
             // Find the view holder
             RecyclerView.ViewHolder holder = mRecyclerView.getChildViewHolder(child);
 

--- a/tableview/src/main/java/com/evrencoskun/tableview/listener/itemclick/ColumnHeaderRecyclerViewItemClickListener.java
+++ b/tableview/src/main/java/com/evrencoskun/tableview/listener/itemclick/ColumnHeaderRecyclerViewItemClickListener.java
@@ -74,7 +74,6 @@ public class ColumnHeaderRecyclerViewItemClickListener extends AbstractItemClick
         View child = mRecyclerView.findChildViewUnder(e.getX(), e.getY());
 
         if (child != null) {
-            getTableViewListener();
             // Find the view holder
             RecyclerView.ViewHolder holder = mRecyclerView.getChildViewHolder(child);
 

--- a/tableview/src/main/java/com/evrencoskun/tableview/listener/itemclick/RowHeaderRecyclerViewItemClickListener.java
+++ b/tableview/src/main/java/com/evrencoskun/tableview/listener/itemclick/RowHeaderRecyclerViewItemClickListener.java
@@ -72,7 +72,6 @@ public class RowHeaderRecyclerViewItemClickListener extends AbstractItemClickLis
         View child = mRecyclerView.findChildViewUnder(e.getX(), e.getY());
 
         if (child != null) {
-            getTableViewListener();
             // Find the view holder
             RecyclerView.ViewHolder holder = mRecyclerView.getChildViewHolder(child);
 


### PR DESCRIPTION
In #237, I changed a `Map<Integer, Map<Integer, Integer>>` with a `SparseArray<SparseIntArray>`, as suggested by Android Studio.
However, when retrieving an nonexistent value from a `SparseIntArray`, it returns `0` by default, instead of `-1`, as expected by `CellLayoutManager#getCacheWidth(int, int)`.
I updated that so it now returns `-1` when retrieving a missing value.