### PR TITLE
Fix crash in SavedState when activity is restored

### DIFF
--- a/tableview/src/main/java/com/evrencoskun/tableview/preference/SavedState.java
+++ b/tableview/src/main/java/com/evrencoskun/tableview/preference/SavedState.java
@@ -35,7 +35,7 @@ public class SavedState extends View.BaseSavedState {
 
     private SavedState(Parcel in) {
         super(in);
-
+        preferences = in.readParcelable(Preferences.class.getClassLoader());
     }
 
     @Override


### PR DESCRIPTION
When you enable `Don't keep activities` in the developer debug settings and tab out and in of your app you will get a crash when TableViews are restored.

This fixes the crash.