### PR TITLE
Fix crash on double click on a cell

### DIFF
--- a/tableview/src/main/java/com/evrencoskun/tableview/listener/itemclick/AbstractItemClickListener.java
+++ b/tableview/src/main/java/com/evrencoskun/tableview/listener/itemclick/AbstractItemClickListener.java
@@ -114,5 +114,5 @@ public abstract class AbstractItemClickListener implements RecyclerView.OnItemTo
 
     abstract protected void longPressAction(@NonNull MotionEvent e);
 
-    abstract protected boolean doubleClickAction(MotionEvent e);
+    abstract protected boolean doubleClickAction(@NonNull MotionEvent e);
 }

--- a/tableview/src/main/java/com/evrencoskun/tableview/listener/itemclick/CellRecyclerViewItemClickListener.java
+++ b/tableview/src/main/java/com/evrencoskun/tableview/listener/itemclick/CellRecyclerViewItemClickListener.java
@@ -98,9 +98,9 @@ public class CellRecyclerViewItemClickListener extends AbstractItemClickListener
     }
 
     @Override
-    protected boolean doubleClickAction(MotionEvent e) {
+    protected boolean doubleClickAction(@NonNull MotionEvent e) {
         // Get interacted view from x,y coordinate.
-        View childView = mCellRecyclerView.findChildViewUnder(e.getX(), e.getY());
+        View childView = mRecyclerView.findChildViewUnder(e.getX(), e.getY());
 
         if (childView != null) {
             // Find the view holder

--- a/tableview/src/main/java/com/evrencoskun/tableview/listener/itemclick/ColumnHeaderRecyclerViewItemClickListener.java
+++ b/tableview/src/main/java/com/evrencoskun/tableview/listener/itemclick/ColumnHeaderRecyclerViewItemClickListener.java
@@ -83,7 +83,7 @@ public class ColumnHeaderRecyclerViewItemClickListener extends AbstractItemClick
     }
 
     @Override
-    protected boolean doubleClickAction(MotionEvent e) {
+    protected boolean doubleClickAction(@NonNull MotionEvent e) {
         // Get interacted view from x,y coordinate.
         View childView = mRecyclerView.findChildViewUnder(e.getX(), e.getY());
 

--- a/tableview/src/main/java/com/evrencoskun/tableview/listener/itemclick/RowHeaderRecyclerViewItemClickListener.java
+++ b/tableview/src/main/java/com/evrencoskun/tableview/listener/itemclick/RowHeaderRecyclerViewItemClickListener.java
@@ -81,7 +81,7 @@ public class RowHeaderRecyclerViewItemClickListener extends AbstractItemClickLis
     }
 
     @Override
-    protected boolean doubleClickAction(MotionEvent e) {
+    protected boolean doubleClickAction(@NonNull MotionEvent e) {
         // Get interacted view from x,y coordinate.
         View childView = mRecyclerView.findChildViewUnder(e.getX(), e.getY());
 


### PR DESCRIPTION
Currently, when double clicking on a cell in a `TableView`, the app crashes (this can be reproduce in the sample app).
This PR fixes this issue.