### PR TITLE
Set UNSELECTED_POSITION from SelectionHandler.unselectedCellView()

### DIFF
--- a/tableview/src/main/java/com/evrencoskun/tableview/handler/SelectionHandler.java
+++ b/tableview/src/main/java/com/evrencoskun/tableview/handler/SelectionHandler.java
@@ -203,6 +203,10 @@ public class SelectionHandler {
         AbstractViewHolder rowHeader = (AbstractViewHolder) mRowHeaderRecyclerView
                 .findViewHolderForAdapterPosition(mSelectedRowPosition);
 
+        // Clear selected row and column
+        mSelectedRowPosition = UNSELECTED_POSITION;
+        mSelectedColumnPosition = UNSELECTED_POSITION;
+
         // If view is null, that means the row view holder was already recycled.
         if (rowHeader != null) {
             // Change color


### PR DESCRIPTION
`SelectionHandler` tracks which row and column is currently selected with `mSelectedRowPosition` `mSelectedColumnPosition` variables. When clearing the selection, these should also be set to UNSELECTED_POSITION. If this is not done, when the previously selected cell is scrolled out of view and then back, the previous selection will be restored when the viewholder is bound again