### PR TITLE
Add option to display the Corner View when there are Column headers but no rows or cells

### DIFF
--- a/tableview/build.gradle
+++ b/tableview/build.gradle
@@ -17,6 +17,11 @@ android {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
+        debug {
+            minifyEnabled false
+            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            testCoverageEnabled true
+        }
     }
 
     compileOptions {
@@ -43,8 +48,14 @@ android {
 
 dependencies {
     implementation "androidx.annotation:annotation:$androidx_annotation_version"
-    implementation "androidx.core:core:$androidx_core_version"
     implementation "androidx.recyclerview:recyclerview:$androidx_recyclerview_version"
+    testImplementation "junit:junit:4.13"
+    androidTestImplementation 'androidx.test:rules:1.2.0'
+    androidTestImplementation 'androidx.test:runner:1.2.0'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.1'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
+    androidTestImplementation 'androidx.test.espresso:espresso-contrib:3.2.0'
+    androidTestImplementation 'junit:junit:4.12'
 }
 
 publish {

--- a/tableview/src/androidTest/AndroidManifest.xml
+++ b/tableview/src/androidTest/AndroidManifest.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest package="com.evrencoskun.tableview.test"
+          xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <application>
+        <activity android:name=".TestActivity">
+        </activity>
+    </application>
+
+</manifest>

--- a/tableview/src/androidTest/java/com/evrencoskun/tableview/test/CornerViewTest.java
+++ b/tableview/src/androidTest/java/com/evrencoskun/tableview/test/CornerViewTest.java
@@ -1,0 +1,403 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Andrew Beck
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.evrencoskun.tableview.test;
+
+import android.app.Activity;
+import android.view.View;
+import android.widget.LinearLayout;
+import android.widget.TextView;
+
+import androidx.test.platform.app.InstrumentationRegistry;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.rule.ActivityTestRule;
+
+import com.evrencoskun.tableview.*;
+import com.evrencoskun.tableview.test.adapters.SimpleTestAdapter;
+import com.evrencoskun.tableview.test.data.SimpleData;
+
+
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(AndroidJUnit4.class)
+public class CornerViewTest {
+
+    @Rule
+    public ActivityTestRule<TestActivity> mActivityTestRule =
+            new ActivityTestRule<TestActivity>(TestActivity.class){
+
+                @Override
+                protected void beforeActivityLaunched() {
+                    super.beforeActivityLaunched();
+                }
+
+                @Override
+                protected void afterActivityFinished(){
+                    super.afterActivityFinished();
+                }
+            };
+
+    @Test
+    public void testEmptyTable() throws Throwable {
+        Activity activity = mActivityTestRule.getActivity();
+
+        TableView tableView =
+                new TableView(InstrumentationRegistry.getInstrumentation().getTargetContext());
+        Assert.assertNotNull(tableView);
+
+        SimpleTestAdapter simpleTestAdapter = new SimpleTestAdapter();
+        Assert.assertNotNull(simpleTestAdapter);
+
+        tableView.setAdapter(simpleTestAdapter);
+
+        SimpleData simpleData = new SimpleData(0);
+
+        simpleTestAdapter.setAllItems(simpleData.getColumnHeaders(), simpleData.getRowHeaders(),
+                simpleData.getCells());
+
+        mActivityTestRule.runOnUiThread(() -> activity.setContentView(tableView));
+
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync();
+
+        // Check that the corner view is not created (therefore not shown)
+        View cornerView = tableView.getAdapter().getCornerView();
+        Assert.assertNull(cornerView);
+    }
+
+    @Test
+    public void testEmptyTableResetNonEmptyTable() throws Throwable {
+        Activity activity = mActivityTestRule.getActivity();
+
+        TableView tableView =
+                new TableView(InstrumentationRegistry.getInstrumentation().getTargetContext());
+        Assert.assertNotNull(tableView);
+
+        SimpleTestAdapter simpleTestAdapter = new SimpleTestAdapter();
+        Assert.assertNotNull(simpleTestAdapter);
+
+        tableView.setAdapter(simpleTestAdapter);
+
+        SimpleData simpleData = new SimpleData(0);
+
+        simpleTestAdapter.setAllItems(simpleData.getColumnHeaders(), simpleData.getRowHeaders(),
+                simpleData.getCells());
+
+        // Check that the corner view is not created (therefore not shown)
+        View cornerView = tableView.getAdapter().getCornerView();
+        Assert.assertNull(cornerView);
+
+        // Change the items of data to reset
+        SimpleData simpleDataReset = new SimpleData(2);
+        simpleTestAdapter.setAllItems(simpleDataReset.getColumnHeaders(), simpleDataReset.getRowHeaders(),
+                simpleDataReset.getCells());
+
+        mActivityTestRule.runOnUiThread(() -> activity.setContentView(tableView));
+
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync();
+
+        // Check that the corner view is now created
+        // The Corner view uses cell_layout which has LinearLayout as top item
+        LinearLayout cornerViewReset = (LinearLayout) tableView.getAdapter().getCornerView();
+        Assert.assertNotNull(cornerViewReset);
+        // Check the corner view is now visible
+        Assert.assertEquals(View.VISIBLE, cornerViewReset.getVisibility());
+        // Check that it is the expected corner view by checking the text
+        // The first child of the LinearLayout is a textView (index starts at zero)
+        TextView cornerViewResetTextView = (TextView) cornerViewReset.getChildAt(0);
+        Assert.assertEquals("Cell Data", cornerViewResetTextView.getText());
+    }
+
+    @Test
+    public void testEmptyTableResetEmptyTable() throws Throwable {
+        Activity activity = mActivityTestRule.getActivity();
+
+        TableView tableView =
+                new TableView(InstrumentationRegistry.getInstrumentation().getTargetContext());
+        Assert.assertNotNull(tableView);
+
+        SimpleTestAdapter simpleTestAdapter = new SimpleTestAdapter();
+        Assert.assertNotNull(simpleTestAdapter);
+
+        tableView.setAdapter(simpleTestAdapter);
+
+        SimpleData simpleData = new SimpleData(0);
+
+        simpleTestAdapter.setAllItems(simpleData.getColumnHeaders(), simpleData.getRowHeaders(),
+                simpleData.getCells());
+
+        // Check that the corner view is not created (therefore not shown)
+        View cornerView = tableView.getAdapter().getCornerView();
+        Assert.assertNull(cornerView);
+
+        // Change the items of data to reset
+        SimpleData simpleDataReset = new SimpleData(0);
+        simpleTestAdapter.setAllItems(simpleDataReset.getColumnHeaders(), simpleDataReset.getRowHeaders(),
+                simpleDataReset.getCells());
+
+        mActivityTestRule.runOnUiThread(() -> activity.setContentView(tableView));
+
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync();
+
+        // Check that the corner view is still not created
+        // The Corner view uses cell_layout which has LinearLayout as top item
+        LinearLayout cornerViewReset = (LinearLayout) tableView.getAdapter().getCornerView();
+        Assert.assertNull(cornerViewReset);
+    }
+
+    @Test
+    public void testNonEmptyTable() throws Throwable {
+        Activity activity = mActivityTestRule.getActivity();
+
+        TableView tableView =
+                new TableView(InstrumentationRegistry.getInstrumentation().getTargetContext());
+        Assert.assertNotNull(tableView);
+
+        SimpleTestAdapter simpleTestAdapter = new SimpleTestAdapter();
+        Assert.assertNotNull(simpleTestAdapter);
+
+        tableView.setAdapter(simpleTestAdapter);
+
+        SimpleData simpleData = new SimpleData(1);
+
+        simpleTestAdapter.setAllItems(simpleData.getColumnHeaders(), simpleData.getRowHeaders(),
+                simpleData.getCells());
+
+        mActivityTestRule.runOnUiThread(() -> activity.setContentView(tableView));
+
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync();
+
+        // Check that the corner view is created
+        // The Corner view uses cell_layout which has LinearLayout as top item
+        LinearLayout cornerView = (LinearLayout) tableView.getAdapter().getCornerView();
+        Assert.assertNotNull(cornerView);
+        // Check the corner view is visible
+        Assert.assertEquals(View.VISIBLE, cornerView.getVisibility());
+        // Check that it is the expected corner view by checking the text
+        // The first child of the LinearLayout is a textView (index starts at zero)
+        TextView cornerViewTextView = (TextView) cornerView.getChildAt(0);
+        Assert.assertEquals("Cell Data", cornerViewTextView.getText());
+    }
+
+    @Test
+    public void testNonEmptyTableResetNonEmpty() throws Throwable {
+        Activity activity = mActivityTestRule.getActivity();
+
+        TableView tableView =
+                new TableView(InstrumentationRegistry.getInstrumentation().getTargetContext());
+        Assert.assertNotNull(tableView);
+
+        SimpleTestAdapter simpleTestAdapter = new SimpleTestAdapter();
+        Assert.assertNotNull(simpleTestAdapter);
+
+        tableView.setAdapter(simpleTestAdapter);
+
+        SimpleData simpleData = new SimpleData(1);
+
+        simpleTestAdapter.setAllItems(simpleData.getColumnHeaders(), simpleData.getRowHeaders(),
+                simpleData.getCells());
+
+        // Check that the corner view is created before resetting to empty
+        // The Corner view uses cell_layout which has LinearLayout as top item
+        LinearLayout cornerView = (LinearLayout) tableView.getAdapter().getCornerView();
+        Assert.assertNotNull(cornerView);
+        // Check the corner view is visible
+        Assert.assertEquals(View.VISIBLE, cornerView.getVisibility());
+
+        // Change the items of data to reset
+        SimpleData simpleDataReset = new SimpleData(2);
+        simpleTestAdapter.setAllItems(simpleDataReset.getColumnHeaders(), simpleDataReset.getRowHeaders(),
+                simpleDataReset.getCells());
+
+        mActivityTestRule.runOnUiThread(() -> activity.setContentView(tableView));
+
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync();
+
+        // Check that the corner view is still created
+        // The Corner view uses cell_layout which has LinearLayout as top item
+        LinearLayout cornerViewReset = (LinearLayout) tableView.getAdapter().getCornerView();
+        Assert.assertNotNull(cornerViewReset);
+        // Check the corner view is still visible
+        Assert.assertEquals(View.VISIBLE, cornerViewReset.getVisibility());
+        // Check that it is the expected corner view by checking the text
+        // The first child of the LinearLayout is a textView (index starts at zero)
+        TextView cornerViewResetTextView = (TextView) cornerViewReset.getChildAt(0);
+        Assert.assertEquals("Cell Data", cornerViewResetTextView.getText());
+    }
+
+    @Test
+    public void testNonEmptyTableResetEmpty() throws Throwable {
+        Activity activity = mActivityTestRule.getActivity();
+
+        TableView tableView =
+                new TableView(InstrumentationRegistry.getInstrumentation().getTargetContext());
+        Assert.assertNotNull(tableView);
+
+        SimpleTestAdapter simpleTestAdapter = new SimpleTestAdapter();
+        Assert.assertNotNull(simpleTestAdapter);
+
+        tableView.setAdapter(simpleTestAdapter);
+
+        SimpleData simpleData = new SimpleData(1);
+
+        simpleTestAdapter.setAllItems(simpleData.getColumnHeaders(), simpleData.getRowHeaders(),
+                simpleData.getCells());
+
+        // Check that the corner view is created before resetting to empty
+        // The Corner view uses cell_layout which has LinearLayout as top item
+        LinearLayout cornerView = (LinearLayout) tableView.getAdapter().getCornerView();
+        Assert.assertNotNull(cornerView);
+
+        // Change the items of data to reset
+        SimpleData simpleDataReset = new SimpleData(0);
+        simpleTestAdapter.setAllItems(simpleDataReset.getColumnHeaders(), simpleDataReset.getRowHeaders(),
+                simpleDataReset.getCells());
+
+        mActivityTestRule.runOnUiThread(() -> activity.setContentView(tableView));
+
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync();
+
+        // Check that the corner view is still created but visibility is gone
+        // The Corner view uses cell_layout which has LinearLayout as top item
+        LinearLayout cornerViewReset = (LinearLayout) tableView.getAdapter().getCornerView();
+        Assert.assertNotNull(cornerViewReset);
+        // Check the corner view visibility is GONE
+        Assert.assertEquals(View.GONE, cornerViewReset.getVisibility());
+    }
+
+    @Test
+    public void testColumnHeadersOnlyTable() throws Throwable {
+        Activity activity = mActivityTestRule.getActivity();
+
+        TableView tableView =
+                new TableView(InstrumentationRegistry.getInstrumentation().getTargetContext());
+        Assert.assertNotNull(tableView);
+
+        SimpleTestAdapter simpleTestAdapter = new SimpleTestAdapter();
+        Assert.assertNotNull(simpleTestAdapter);
+
+        tableView.setAdapter(simpleTestAdapter);
+
+        // Only want column headers
+        SimpleData simpleData = new SimpleData(5, 0);
+
+        simpleTestAdapter.setAllItems(simpleData.getColumnHeaders(), simpleData.getRowHeaders(),
+                simpleData.getCells());
+
+        mActivityTestRule.runOnUiThread(() -> activity.setContentView(tableView));
+
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync();
+
+        // Check that the corner view is not created
+        // The Corner view uses cell_layout which has LinearLayout as top item
+        LinearLayout cornerView = (LinearLayout) tableView.getAdapter().getCornerView();
+        Assert.assertNull(cornerView);
+    }
+
+    @Test
+    public void testColumnHeadersOnlyTableResetNonEmptyTable() throws Throwable {
+        Activity activity = mActivityTestRule.getActivity();
+
+        TableView tableView =
+                new TableView(InstrumentationRegistry.getInstrumentation().getTargetContext());
+        Assert.assertNotNull(tableView);
+
+        SimpleTestAdapter simpleTestAdapter = new SimpleTestAdapter();
+        Assert.assertNotNull(simpleTestAdapter);
+
+        tableView.setAdapter(simpleTestAdapter);
+
+        // Only want column headers
+        SimpleData simpleData = new SimpleData(5, 0);
+
+        simpleTestAdapter.setAllItems(simpleData.getColumnHeaders(), simpleData.getRowHeaders(),
+                simpleData.getCells());
+
+        // Check that the corner view is not created
+        // The Corner view uses cell_layout which has LinearLayout as top item
+        LinearLayout cornerView = (LinearLayout) tableView.getAdapter().getCornerView();
+        Assert.assertNull(cornerView);
+
+        // Change the items of data to reset
+        SimpleData simpleDataReset = new SimpleData(5);
+        simpleTestAdapter.setAllItems(simpleDataReset.getColumnHeaders(), simpleDataReset.getRowHeaders(),
+                simpleDataReset.getCells());
+
+        mActivityTestRule.runOnUiThread(() -> activity.setContentView(tableView));
+
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync();
+
+        // Check that the corner view is not created
+        // The Corner view uses cell_layout which has LinearLayout as top item
+        LinearLayout cornerViewReset = (LinearLayout) tableView.getAdapter().getCornerView();
+        Assert.assertNotNull(cornerViewReset);
+        // Check the corner view is now visible
+        Assert.assertEquals(View.VISIBLE, cornerViewReset.getVisibility());
+        // Check that it is the expected corner view by checking the text
+        // The first child of the LinearLayout is a textView (index starts at zero)
+        TextView cornerViewResetTextView = (TextView) cornerViewReset.getChildAt(0);
+        Assert.assertEquals("Cell Data", cornerViewResetTextView.getText());
+    }
+
+    @Test
+    public void testColumnHeadersOnlyTableResetEmptyTable() throws Throwable {
+        Activity activity = mActivityTestRule.getActivity();
+
+        TableView tableView =
+                new TableView(InstrumentationRegistry.getInstrumentation().getTargetContext());
+        Assert.assertNotNull(tableView);
+
+        SimpleTestAdapter simpleTestAdapter = new SimpleTestAdapter();
+        Assert.assertNotNull(simpleTestAdapter);
+
+        tableView.setAdapter(simpleTestAdapter);
+
+        // Only want column headers
+        SimpleData simpleData = new SimpleData(5, 0);
+
+        simpleTestAdapter.setAllItems(simpleData.getColumnHeaders(), simpleData.getRowHeaders(),
+                simpleData.getCells());
+
+        // Check that the corner view is not created
+        // The Corner view uses cell_layout which has LinearLayout as top item
+        LinearLayout cornerView = (LinearLayout) tableView.getAdapter().getCornerView();
+        Assert.assertNull(cornerView);
+
+        // Change the items of data to reset
+        SimpleData simpleDataReset = new SimpleData(0);
+        simpleTestAdapter.setAllItems(simpleDataReset.getColumnHeaders(), simpleDataReset.getRowHeaders(),
+                simpleDataReset.getCells());
+
+        mActivityTestRule.runOnUiThread(() -> activity.setContentView(tableView));
+
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync();
+
+        // Check that the corner view is not created
+        // The Corner view uses cell_layout which has LinearLayout as top item
+        LinearLayout cornerViewReset = (LinearLayout) tableView.getAdapter().getCornerView();
+        Assert.assertNull(cornerViewReset);
+    }
+}

--- a/tableview/src/androidTest/java/com/evrencoskun/tableview/test/CornerViewTest.java
+++ b/tableview/src/androidTest/java/com/evrencoskun/tableview/test/CornerViewTest.java
@@ -400,4 +400,130 @@ public class CornerViewTest {
         LinearLayout cornerViewReset = (LinearLayout) tableView.getAdapter().getCornerView();
         Assert.assertNull(cornerViewReset);
     }
+
+    @Test
+    public void testColumnHeadersOnlyTableShowCorner() throws Throwable {
+        Activity activity = mActivityTestRule.getActivity();
+
+        TableView tableView =
+                new TableView(InstrumentationRegistry.getInstrumentation().getTargetContext());
+        Assert.assertNotNull(tableView);
+
+        // Set the option to show corner view when there is not row data
+        tableView.setShowCornerView(true);
+
+        SimpleTestAdapter simpleTestAdapter = new SimpleTestAdapter();
+        Assert.assertNotNull(simpleTestAdapter);
+
+        tableView.setAdapter(simpleTestAdapter);
+
+        // Only want column headers
+        SimpleData simpleData = new SimpleData(5, 0);
+
+        simpleTestAdapter.setAllItems(simpleData.getColumnHeaders(), simpleData.getRowHeaders(),
+                simpleData.getCells());
+
+        mActivityTestRule.runOnUiThread(() -> activity.setContentView(tableView));
+
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync();
+
+        // Check that the corner view is created
+        // The Corner view uses cell_layout which has LinearLayout as top item
+        LinearLayout cornerView = (LinearLayout) tableView.getAdapter().getCornerView();
+        Assert.assertNotNull(cornerView);
+        // Check the corner view is visible
+        Assert.assertEquals(View.VISIBLE, cornerView.getVisibility());
+        // Check that it is the expected corner view by checking the text
+        // The first child of the LinearLayout is a textView (index starts at zero)
+        TextView cornerViewResetTextView = (TextView) cornerView.getChildAt(0);
+        Assert.assertEquals("Cell Data", cornerViewResetTextView.getText());
+    }
+
+    @Test
+    public void testColumnHeadersOnlyTableShowCornerResetEmptyTable() throws Throwable {
+        Activity activity = mActivityTestRule.getActivity();
+
+        TableView tableView =
+                new TableView(InstrumentationRegistry.getInstrumentation().getTargetContext());
+        Assert.assertNotNull(tableView);
+
+        // Set the option to show corner view when there is not row data
+        tableView.setShowCornerView(true);
+
+        SimpleTestAdapter simpleTestAdapter = new SimpleTestAdapter();
+        Assert.assertNotNull(simpleTestAdapter);
+
+        tableView.setAdapter(simpleTestAdapter);
+
+        // Only want column headers
+        SimpleData simpleData = new SimpleData(5, 0);
+
+        simpleTestAdapter.setAllItems(simpleData.getColumnHeaders(), simpleData.getRowHeaders(),
+                simpleData.getCells());
+
+        // Check that the corner view is created
+        // The Corner view uses cell_layout which has LinearLayout as top item
+        LinearLayout cornerView = (LinearLayout) tableView.getAdapter().getCornerView();
+        Assert.assertNotNull(cornerView);
+
+        // Change the items of data to reset
+        SimpleData simpleDataReset = new SimpleData(0);
+        simpleTestAdapter.setAllItems(simpleDataReset.getColumnHeaders(), simpleDataReset.getRowHeaders(),
+                simpleDataReset.getCells());
+
+        mActivityTestRule.runOnUiThread(() -> activity.setContentView(tableView));
+
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync();
+
+        // Check that the corner view is still created
+        // The Corner view uses cell_layout which has LinearLayout as top item
+        LinearLayout cornerViewReset = (LinearLayout) tableView.getAdapter().getCornerView();
+        Assert.assertNotNull(cornerViewReset);
+        // Check the corner view visibility is GONE
+        Assert.assertEquals(View.GONE, cornerViewReset.getVisibility());
+    }
+
+    @Test
+    public void testColumnHeadersOnlyTableShowCornerResetNonEmptyTable() throws Throwable {
+        Activity activity = mActivityTestRule.getActivity();
+
+        TableView tableView =
+                new TableView(InstrumentationRegistry.getInstrumentation().getTargetContext());
+        Assert.assertNotNull(tableView);
+
+        // Set the option to show corner view when there is not row data
+        tableView.setShowCornerView(true);
+
+        SimpleTestAdapter simpleTestAdapter = new SimpleTestAdapter();
+        Assert.assertNotNull(simpleTestAdapter);
+
+        tableView.setAdapter(simpleTestAdapter);
+
+        // Only want column headers
+        SimpleData simpleData = new SimpleData(5, 0);
+
+        simpleTestAdapter.setAllItems(simpleData.getColumnHeaders(), simpleData.getRowHeaders(),
+                simpleData.getCells());
+
+        // Check that the corner view is created
+        // The Corner view uses cell_layout which has LinearLayout as top item
+        LinearLayout cornerView = (LinearLayout) tableView.getAdapter().getCornerView();
+        Assert.assertNotNull(cornerView);
+
+        // Change the items of data to reset
+        SimpleData simpleDataReset = new SimpleData(2);
+        simpleTestAdapter.setAllItems(simpleDataReset.getColumnHeaders(), simpleDataReset.getRowHeaders(),
+                simpleDataReset.getCells());
+
+        mActivityTestRule.runOnUiThread(() -> activity.setContentView(tableView));
+
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync();
+
+        // Check that the corner view is still created
+        // The Corner view uses cell_layout which has LinearLayout as top item
+        LinearLayout cornerViewReset = (LinearLayout) tableView.getAdapter().getCornerView();
+        Assert.assertNotNull(cornerViewReset);
+        // Check the corner view visibility is VISIBLE
+        Assert.assertEquals(View.VISIBLE, cornerViewReset.getVisibility());
+    }
 }

--- a/tableview/src/androidTest/java/com/evrencoskun/tableview/test/SimpleActivityTest.java
+++ b/tableview/src/androidTest/java/com/evrencoskun/tableview/test/SimpleActivityTest.java
@@ -1,0 +1,133 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Andrew Beck
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.evrencoskun.tableview.test;
+
+import android.app.Activity;
+import android.widget.LinearLayout;
+import android.widget.TextView;
+
+import androidx.test.platform.app.InstrumentationRegistry;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.rule.ActivityTestRule;
+
+import com.evrencoskun.tableview.*;
+import com.evrencoskun.tableview.test.adapters.SimpleTestAdapter;
+import com.evrencoskun.tableview.test.data.SimpleData;
+
+
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(AndroidJUnit4.class)
+public class SimpleActivityTest {
+
+    @Rule
+    public ActivityTestRule<TestActivity> mActivityTestRule =
+            new ActivityTestRule<TestActivity>(TestActivity.class){
+
+        @Override
+        protected void beforeActivityLaunched() {
+            super.beforeActivityLaunched();
+        }
+
+        @Override
+        protected void afterActivityFinished(){
+            super.afterActivityFinished();
+        }
+    };
+
+    @Test
+    public void testTableViewCreate(){
+        TableView tableView =
+                new TableView(InstrumentationRegistry.getInstrumentation().getTargetContext());
+        Assert.assertNotNull(tableView);
+    }
+
+    @Test
+    public void testDefaults(){
+        TableView tableView =
+                new TableView(InstrumentationRegistry.getInstrumentation().getTargetContext());
+        Assert.assertFalse(tableView.isAllowClickInsideCell());
+        Assert.assertTrue(tableView.isShowHorizontalSeparators());
+        Assert.assertTrue(tableView.isShowVerticalSeparators());
+    }
+
+    @Test
+    public void testSetAttributes(){
+        TableView tableView =
+                new TableView(InstrumentationRegistry.getInstrumentation().getTargetContext());
+        Assert.assertFalse(tableView.isAllowClickInsideCell());
+        Assert.assertTrue(tableView.isShowHorizontalSeparators());
+        Assert.assertTrue(tableView.isShowVerticalSeparators());
+    }
+
+    @Test
+    public void testAdapterCreate(){
+        SimpleTestAdapter simpleTestAdapter = new SimpleTestAdapter();
+        Assert.assertNotNull(simpleTestAdapter);
+    }
+
+    @Test
+    public void testSmallTable() throws Throwable {
+        Activity activity = mActivityTestRule.getActivity();
+
+        TableView tableView =
+                new TableView(InstrumentationRegistry.getInstrumentation().getTargetContext());
+        Assert.assertNotNull(tableView);
+
+        SimpleTestAdapter simpleTestAdapter = new SimpleTestAdapter();
+        Assert.assertNotNull(simpleTestAdapter);
+
+        tableView.setAdapter(simpleTestAdapter);
+
+        SimpleData simpleData = new SimpleData(5);
+
+        simpleTestAdapter.setAllItems(simpleData.getColumnHeaders(), simpleData.getRowHeaders(),
+                simpleData.getCells());
+
+        mActivityTestRule.runOnUiThread(() -> activity.setContentView(tableView));
+
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync();
+
+        // Check that the row header was created as expected at 5th Row (index starts at zero)
+        // cell_layout has LinearLayout as top item
+        LinearLayout rowLinearLayout = (LinearLayout) tableView.getRowHeaderLayoutManager().getChildAt(4);
+        Assert.assertNotNull(rowLinearLayout);
+        // The first child of the LinearLayout is a textView (index starts at zero)
+        TextView rowTextView = (TextView) rowLinearLayout.getChildAt(0);
+        Assert.assertEquals("r:4", rowTextView.getText());
+
+        // Check that the column header was created as expected at 5th Row (index starts at zero)
+        // cell_layout has LinearLayout as top item
+        LinearLayout columnLinearLayout = (LinearLayout) tableView.getColumnHeaderLayoutManager().getChildAt(4);
+        Assert.assertNotNull(columnLinearLayout);
+        // The first child of the LinearLayout is a textView (index starts at zero)
+        TextView columnTextView = (TextView) columnLinearLayout.getChildAt(0);
+        Assert.assertEquals("c:4", columnTextView.getText());
+
+    }
+}

--- a/tableview/src/androidTest/java/com/evrencoskun/tableview/test/TestActivity.java
+++ b/tableview/src/androidTest/java/com/evrencoskun/tableview/test/TestActivity.java
@@ -1,0 +1,30 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Andrew Beck
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.evrencoskun.tableview.test;
+
+import android.app.Activity;
+
+public class TestActivity extends Activity {
+}

--- a/tableview/src/androidTest/java/com/evrencoskun/tableview/test/adapters/SimpleTestAdapter.java
+++ b/tableview/src/androidTest/java/com/evrencoskun/tableview/test/adapters/SimpleTestAdapter.java
@@ -1,0 +1,115 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Andrew Beck
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.evrencoskun.tableview.test.adapters;
+
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.LinearLayout;
+import android.widget.TextView;
+
+import androidx.annotation.NonNull;
+
+import com.evrencoskun.tableview.test.R;
+import com.evrencoskun.tableview.adapter.AbstractTableAdapter;
+import com.evrencoskun.tableview.adapter.recyclerview.holder.AbstractViewHolder;
+import com.evrencoskun.tableview.test.models.Cell;
+import com.evrencoskun.tableview.test.models.ColumnHeader;
+import com.evrencoskun.tableview.test.models.RowHeader;
+
+public class SimpleTestAdapter extends AbstractTableAdapter<ColumnHeader, RowHeader, Cell> {
+
+    static class TestCellViewHolder extends AbstractViewHolder {
+
+        final LinearLayout cell_container;
+        final TextView cell_textview;
+
+        TestCellViewHolder(View itemView) {
+            super(itemView);
+            cell_container = itemView.findViewById(com.evrencoskun.tableview.test.R.id.cell_container);
+            cell_textview = itemView.findViewById(com.evrencoskun.tableview.test.R.id.cell_data);
+        }
+    }
+
+    @NonNull
+    public AbstractViewHolder onCreateCellViewHolder(ViewGroup parent, int viewType) {
+        View layout = LayoutInflater.from(parent.getContext())
+                .inflate(R.layout.cell_layout, parent, false);
+        return new TestCellViewHolder(layout);
+    }
+
+    public void onBindCellViewHolder(@NonNull AbstractViewHolder holder, Cell cell, int
+            columnPosition, int rowPosition) {
+
+        TestCellViewHolder viewHolder = (TestCellViewHolder) holder;
+        viewHolder.cell_textview.setText(cell.getData() != null ? cell.getData().toString() : "");
+
+        viewHolder.cell_container.getLayoutParams().width = LinearLayout.LayoutParams.WRAP_CONTENT;
+        viewHolder.cell_textview.requestLayout();
+    }
+
+    @NonNull
+    public AbstractViewHolder onCreateColumnHeaderViewHolder(ViewGroup parent, int viewType) {
+        View layout = LayoutInflater.from(parent.getContext())
+                .inflate(R.layout.cell_layout, parent, false);
+        return new TestCellViewHolder(layout);
+    }
+
+    public void onBindColumnHeaderViewHolder(@NonNull AbstractViewHolder holder,
+                                             ColumnHeader columnHeader, int position) {
+
+        TestCellViewHolder viewHolder = (TestCellViewHolder) holder;
+        if (columnHeader.getData() != null)
+        viewHolder.cell_textview.setText(columnHeader.getData().toString());
+
+        viewHolder.cell_container.getLayoutParams().width = LinearLayout.LayoutParams.WRAP_CONTENT;
+        viewHolder.cell_textview.requestLayout();
+    }
+
+    @NonNull
+    public AbstractViewHolder onCreateRowHeaderViewHolder(ViewGroup parent, int viewType) {
+        View layout = LayoutInflater.from(parent.getContext())
+                .inflate(R.layout.cell_layout, parent, false);
+        return new TestCellViewHolder(layout);
+    }
+
+    public void onBindRowHeaderViewHolder(@NonNull AbstractViewHolder holder,
+                                          RowHeader rowHeader, int position) {
+
+        TestCellViewHolder viewHolder = (TestCellViewHolder) holder;
+        if (rowHeader.getData() != null)
+        viewHolder.cell_textview.setText(rowHeader.getData().toString());
+    }
+
+    @NonNull
+    public View onCreateCornerView(ViewGroup parent) {
+        return LayoutInflater.from(parent.getContext())
+                .inflate(R.layout.cell_layout, parent, false);
+    }
+
+    public int getColumnHeaderItemViewType(int position) { return 0; }
+    public int getRowHeaderItemViewType(int position) { return 0; }
+    public int getCellItemViewType(int position) { return 0; }
+}

--- a/tableview/src/androidTest/java/com/evrencoskun/tableview/test/data/SimpleData.java
+++ b/tableview/src/androidTest/java/com/evrencoskun/tableview/test/data/SimpleData.java
@@ -1,0 +1,92 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Andrew Beck
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.evrencoskun.tableview.test.data;
+
+import com.evrencoskun.tableview.test.models.Cell;
+import com.evrencoskun.tableview.test.models.ColumnHeader;
+import com.evrencoskun.tableview.test.models.RowHeader;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class SimpleData {
+    private List<List<Cell>> cells;
+    private List<ColumnHeader> columnHeaders;
+    private List<RowHeader> rowHeaders;
+
+    public SimpleData(int size){
+        init(size, size);
+    }
+
+    public SimpleData(int columnSize, int rowSize) {
+        init(columnSize, rowSize);
+    }
+
+    private void init(int columnSize, int rowSize) {
+        rowHeaders = new ArrayList<>();
+        for (int i = 0; i < rowSize; i++) {
+            rowHeaders.add(new RowHeader(String.valueOf(i), "r:" + i));
+        }
+
+        columnHeaders = new ArrayList<>();
+        for (int i = 0; i < columnSize; i++) {
+            columnHeaders.add(new ColumnHeader(String.valueOf(i), "c:" + i));
+        }
+
+        cells = new ArrayList<>();
+        for (int i = 0; i < rowSize; i++) {
+            ArrayList<Cell> cellList = new ArrayList<>();
+            for (int j = 0; j < columnSize; j++) {
+                String id = j + ":" + i;
+                cellList.add(new Cell(id, "r:" + i + "c:" + j));
+            }
+            cells.add(cellList);
+        }
+    }
+
+    public List<List<Cell>> getCells() {
+        return cells;
+    }
+
+    public void setCells(List<List<Cell>> cells) {
+        this.cells = cells;
+    }
+
+    public List<ColumnHeader> getColumnHeaders() {
+        return columnHeaders;
+    }
+
+    public void setColumnHeaders(List<ColumnHeader> columnHeaders) {
+        this.columnHeaders = columnHeaders;
+    }
+
+    public List<RowHeader> getRowHeaders() {
+        return rowHeaders;
+    }
+
+    public void setRowHeaders(List<RowHeader> rowHeaders) {
+        this.rowHeaders = rowHeaders;
+    }
+}

--- a/tableview/src/androidTest/java/com/evrencoskun/tableview/test/models/Cell.java
+++ b/tableview/src/androidTest/java/com/evrencoskun/tableview/test/models/Cell.java
@@ -1,0 +1,81 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Andrew Beck
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.evrencoskun.tableview.test.models;
+
+import com.evrencoskun.tableview.filter.IFilterableModel;
+import com.evrencoskun.tableview.sort.ISortableModel;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+public class Cell implements ISortableModel, IFilterableModel {
+    @NonNull
+    private String mId;
+    @Nullable
+    private Object mData;
+    @NonNull
+    private String mFilterKeyword;
+
+    public Cell(@NonNull String id, @Nullable Object data) {
+        this.mId = id;
+        this.mData = data;
+        this.mFilterKeyword = String.valueOf(data);
+    }
+
+    /**
+     * This is necessary for sorting process.
+     * See ISortableModel
+     */
+    @NonNull
+    @Override
+    public String getId() {
+        return mId;
+    }
+
+    /**
+     * This is necessary for sorting process.
+     * See ISortableModel
+     */
+    @Nullable
+    @Override
+    public Object getContent() {
+        return mData;
+    }
+
+    @Nullable
+    public Object getData() {
+        return mData;
+    }
+
+    public void setData(@Nullable Object data) {
+        mData = data;
+    }
+
+    @NonNull
+    @Override
+    public String getFilterableKeyword() {
+        return mFilterKeyword;
+    }
+}

--- a/tableview/src/androidTest/java/com/evrencoskun/tableview/test/models/ColumnHeader.java
+++ b/tableview/src/androidTest/java/com/evrencoskun/tableview/test/models/ColumnHeader.java
@@ -1,0 +1,35 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Andrew Beck
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.evrencoskun.tableview.test.models;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+
+public class ColumnHeader extends Cell {
+    public ColumnHeader(@NonNull String id, @Nullable String data) {
+        super(id, data);
+    }
+}

--- a/tableview/src/androidTest/java/com/evrencoskun/tableview/test/models/RowHeader.java
+++ b/tableview/src/androidTest/java/com/evrencoskun/tableview/test/models/RowHeader.java
@@ -1,0 +1,34 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Andrew Beck
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.evrencoskun.tableview.test.models;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+public class RowHeader extends Cell {
+    public RowHeader(@NonNull String id, @Nullable String data) {
+        super(id, data);
+    }
+}

--- a/tableview/src/androidTest/res/layout/cell_layout.xml
+++ b/tableview/src/androidTest/res/layout/cell_layout.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--
+  ~ MIT License
+  ~
+  ~ Copyright (c) 2020 Andrew Beck
+  ~
+  ~ Permission is hereby granted, free of charge, to any person obtaining a copy
+  ~ of this software and associated documentation files (the "Software"), to deal
+  ~ in the Software without restriction, including without limitation the rights
+  ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  ~ copies of the Software, and to permit persons to whom the Software is
+  ~ furnished to do so, subject to the following conditions:
+  ~
+  ~ The above copyright notice and this permission notice shall be included in all
+  ~ copies or substantial portions of the Software.
+  ~
+  ~ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  ~ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  ~ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  ~ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  ~ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  ~ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  ~ SOFTWARE.
+  -->
+
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/cell_container"
+    android:layout_width="match_parent"
+    android:layout_height="55dp"
+    android:background="@android:color/white"
+    android:gravity="center"
+    android:orientation="vertical">
+
+    <TextView
+        android:id="@+id/cell_data"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_gravity="center_vertical"
+        android:gravity="center"
+        android:maxLines="1"
+        android:text="Cell Data"
+        android:textColor="@android:color/black"
+        android:textSize="12sp" />
+
+</LinearLayout>

--- a/tableview/src/main/java/com/evrencoskun/tableview/ITableView.java
+++ b/tableview/src/main/java/com/evrencoskun/tableview/ITableView.java
@@ -158,6 +158,8 @@ public interface ITableView {
 
     void setRowHeaderWidth(int rowHeaderWidth);
 
+    boolean getShowCornerView();
+
     @Nullable
     AbstractTableAdapter getAdapter();
 

--- a/tableview/src/main/java/com/evrencoskun/tableview/TableView.java
+++ b/tableview/src/main/java/com/evrencoskun/tableview/TableView.java
@@ -116,6 +116,7 @@ public class TableView extends FrameLayout implements ITableView {
     private boolean mAllowClickInsideRowHeader = false;
     private boolean mAllowClickInsideColumnHeader = false;
     private boolean mIsSortable;
+    private boolean mShowCornerView = false;
 
     public TableView(@NonNull Context context) {
         super(context);
@@ -770,6 +771,14 @@ public class TableView extends FrameLayout implements ITableView {
 
     public void setColumnWidth(int columnPosition, int width) {
         mColumnWidthHandler.setColumnWidth(columnPosition, width);
+    }
+
+    public void setShowCornerView(boolean showCornerView){
+        mShowCornerView = showCornerView;
+    }
+
+    public boolean getShowCornerView(){
+        return mShowCornerView;
     }
 
     @Nullable

--- a/tableview/src/main/java/com/evrencoskun/tableview/adapter/AbstractTableAdapter.java
+++ b/tableview/src/main/java/com/evrencoskun/tableview/adapter/AbstractTableAdapter.java
@@ -122,21 +122,34 @@ public abstract class AbstractTableAdapter<CH, RH, C> implements ITableAdapter<C
         setCellItems(cellItems);
 
         // Control corner view
-        if ((columnHeaderItems != null && !columnHeaderItems.isEmpty()) && (rowHeaderItems !=
-                null && !rowHeaderItems.isEmpty()) && (cellItems != null && !cellItems.isEmpty())
-                && mTableView != null && mCornerView == null) {
-
-            // Create corner view
-            mCornerView = onCreateCornerView((ViewGroup) mTableView);
-            mTableView.addView(mCornerView, new FrameLayout.LayoutParams(mRowHeaderWidth,
-                    mColumnHeaderHeight));
-        } else if (mCornerView != null) {
-
-            // Change corner view visibility
-            if (rowHeaderItems != null && !rowHeaderItems.isEmpty()) {
-                mCornerView.setVisibility(View.VISIBLE);
-            } else {
-                mCornerView.setVisibility(View.GONE);
+        if (mCornerView == null){
+            if (columnHeaderItems != null && !columnHeaderItems.isEmpty() && mTableView != null) {
+                // Check to see if the corner view show be shown with column headers
+                if (!mTableView.getShowCornerView()){
+                    // Don't show corner view if there are column headers but
+                    // No row headers or cell data
+                    // (Original behaviour)
+                    if (!(rowHeaderItems != null && !rowHeaderItems.isEmpty() &&
+                            cellItems != null && !cellItems.isEmpty())) {
+                        // There are no row headers or cell items so no corner view is needed
+                        return;
+                    }
+                }
+                // Create corner view
+                mCornerView = onCreateCornerView((ViewGroup) mTableView);
+                mTableView.addView(mCornerView, new FrameLayout.LayoutParams(mRowHeaderWidth,
+                        mColumnHeaderHeight));
+            }
+        } else {
+            // Check to see if the corner view show be shown with column headers
+            if (!mTableView.getShowCornerView()){
+                // (Original behaviour)
+                // Change corner view visibility
+                if (rowHeaderItems != null && !rowHeaderItems.isEmpty()) {
+                    mCornerView.setVisibility(View.VISIBLE);
+                } else {
+                    mCornerView.setVisibility(View.GONE);
+                }
             }
         }
     }

--- a/tableview/src/main/java/com/evrencoskun/tableview/adapter/AbstractTableAdapter.java
+++ b/tableview/src/main/java/com/evrencoskun/tableview/adapter/AbstractTableAdapter.java
@@ -141,15 +141,11 @@ public abstract class AbstractTableAdapter<CH, RH, C> implements ITableAdapter<C
                         mColumnHeaderHeight));
             }
         } else {
-            // Check to see if the corner view show be shown with column headers
-            if (!mTableView.getShowCornerView()){
-                // (Original behaviour)
-                // Change corner view visibility
-                if (rowHeaderItems != null && !rowHeaderItems.isEmpty()) {
-                    mCornerView.setVisibility(View.VISIBLE);
-                } else {
-                    mCornerView.setVisibility(View.GONE);
-                }
+            // Change corner view visibility
+            if (rowHeaderItems != null && !rowHeaderItems.isEmpty()) {
+                mCornerView.setVisibility(View.VISIBLE);
+            } else {
+                mCornerView.setVisibility(View.GONE);
             }
         }
     }


### PR DESCRIPTION
This should resolve the issue #308 

It adds the flag to tableview `tableView.setShowCornerView(true);` to change the behaviour of `setAllItems` in the adaptor.

It also adds automated test instrumented test infrastructure to the tableview to test the behaviour change.  
The test infrastructure is based on ideas of how androidx recyclerview and it's layout managers are tested and how flexbox layout manager is tested.  
Code Coverage for these tests is also enabled (created by running the "createDebugCoverageReport" gradle task in the "tableview" module)

The non "ShowCorner" set of test were developed before "ShowCorner" feature was developed and all passed.  
Code Coverage report before feature for `setAllItems`
![image](https://user-images.githubusercontent.com/13763054/86117743-7b69a200-bac7-11ea-98c0-d07c3a3b2f9d.png)
  
Note some branches not covered as the tests only target the "Is not empty" not the "is not null" condition checks.

Test results after the "ShowCorner" feature
![image](https://user-images.githubusercontent.com/13763054/86117601-3e9dab00-bac7-11ea-85bc-ca552760be6b.png)

Code Coverage report after feature changes for `setAllItems`  
![image](https://user-images.githubusercontent.com/13763054/86117957-e024fc80-bac7-11ea-9cd1-0cf8b50121e0.png)

These tests passed on emulators API 22 and API 29  (Note Instrumented tests are note available before API 21 so cannot be used to cover down to the minimum specified API of 14)

Manual test of the sample app showed no change as this does not exhibit the conditions where the feature changes the behaviour (the sample app also does not enable the feature)

