### PR TITLE
Enable RTL support

### DIFF
--- a/tableview/src/androidTest/java/com/evrencoskun/tableview/test/ReverseLayoutTest.java
+++ b/tableview/src/androidTest/java/com/evrencoskun/tableview/test/ReverseLayoutTest.java
@@ -1,0 +1,200 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Andrew Beck
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.evrencoskun.tableview.test;
+
+import android.app.Activity;
+import android.view.View;
+import android.widget.LinearLayout;
+import android.widget.RelativeLayout;
+import android.widget.TextView;
+
+import androidx.test.platform.app.InstrumentationRegistry;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.rule.ActivityTestRule;
+
+import com.evrencoskun.tableview.*;
+import com.evrencoskun.tableview.test.adapters.CornerTestAdapter;
+import com.evrencoskun.tableview.test.adapters.SimpleTestAdapter;
+import com.evrencoskun.tableview.test.data.SimpleData;
+import com.evrencoskun.tableview.test.matchers.ViewWidthMatcher;
+
+
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static androidx.test.espresso.Espresso.*;
+import static androidx.test.espresso.assertion.PositionAssertions.*;
+import static androidx.test.espresso.assertion.ViewAssertions.matches;
+import static androidx.test.espresso.matcher.ViewMatchers.*;
+
+@RunWith(AndroidJUnit4.class)
+public class ReverseLayoutTest {
+
+    @Rule
+    public ActivityTestRule<TestActivity> mActivityTestRule =
+            new ActivityTestRule<TestActivity>(TestActivity.class){
+
+                @Override
+                protected void beforeActivityLaunched() {
+                    super.beforeActivityLaunched();
+                }
+
+                @Override
+                protected void afterActivityFinished(){
+                    super.afterActivityFinished();
+                }
+            };
+
+    @Test
+    public void testDefaultLayout() throws Throwable {
+        Activity activity = mActivityTestRule.getActivity();
+
+        mActivityTestRule.runOnUiThread(() -> activity.setContentView(R.layout.corner_default));
+
+        TableView tableView =  activity.findViewById(R.id.tableview);
+        Assert.assertNotNull(tableView);
+
+        CornerTestAdapter cornerTestAdapter = new CornerTestAdapter();
+        Assert.assertNotNull(cornerTestAdapter);
+
+        mActivityTestRule.runOnUiThread(() -> tableView.setAdapter(cornerTestAdapter));
+
+        SimpleData simpleData = new SimpleData(5);
+
+        mActivityTestRule.runOnUiThread(() -> cornerTestAdapter.setAllItems(
+                simpleData.getColumnHeaders(), simpleData.getRowHeaders(), simpleData.getCells()));
+
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync();
+
+        // Check that the corner view is created
+        // The Corner view uses cell_layout which has LinearLayout as top item
+        RelativeLayout cornerView = (RelativeLayout) tableView.getAdapter().getCornerView();
+        Assert.assertNotNull(cornerView);
+        // Check the corner view is visible
+        Assert.assertEquals(View.VISIBLE, cornerView.getVisibility());
+        // Check that it is the expected corner view by checking the text
+        // The first child of the RelativeLayout is a textView (index starts at zero)
+        TextView cornerViewTextView = (TextView) cornerView.getChildAt(0);
+        Assert.assertEquals("Corner", cornerViewTextView.getText());
+
+        // Check that column headers are ordered Left to Right
+        onView(withText("c:0")).check(isCompletelyLeftOf(withText("c:1")));
+
+        // Check that first cell data row are ordered Left to Right
+        onView(withText("r:0c:0")).check(isCompletelyLeftOf(withText("r:0c:1")));
+    }
+
+    @Test
+    public void testReverseLayout() throws Throwable {
+        Activity activity = mActivityTestRule.getActivity();
+
+        mActivityTestRule.runOnUiThread(() -> activity.setContentView(R.layout.reverse_layout));
+
+        TableView tableView =  activity.findViewById(R.id.tableview);
+        Assert.assertNotNull(tableView);
+
+        CornerTestAdapter cornerTestAdapter = new CornerTestAdapter();
+        Assert.assertNotNull(cornerTestAdapter);
+
+        mActivityTestRule.runOnUiThread(() -> tableView.setAdapter(cornerTestAdapter));
+
+        SimpleData simpleData = new SimpleData(5);
+
+        mActivityTestRule.runOnUiThread(() -> cornerTestAdapter.setAllItems(
+                simpleData.getColumnHeaders(), simpleData.getRowHeaders(), simpleData.getCells()));
+
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync();
+
+        // Check that the corner view is created
+        // The Corner view uses cell_layout which has LinearLayout as top item
+        RelativeLayout cornerView = (RelativeLayout) tableView.getAdapter().getCornerView();
+        Assert.assertNotNull(cornerView);
+        // Check the corner view is visible
+        Assert.assertEquals(View.VISIBLE, cornerView.getVisibility());
+        // Check that it is the expected corner view by checking the text
+        // The first child of the RelativeLayout is a textView (index starts at zero)
+        TextView cornerViewTextView = (TextView) cornerView.getChildAt(0);
+        Assert.assertEquals("Corner", cornerViewTextView.getText());
+
+        // Check that column headers are ordered Right to Left
+        onView(withText("c:0")).check(isCompletelyRightOf(withText("c:1")));
+
+        // Check that first cell data row are ordered Right to Left
+        onView(withText("r:0c:0")).check(isCompletelyRightOf(withText("r:0c:1")));
+    }
+
+    @Test
+    public void testReverseConstructor() throws Throwable {
+        Activity activity = mActivityTestRule.getActivity();
+
+        TableView tableView =
+                new TableView(InstrumentationRegistry.getInstrumentation().getTargetContext(), false);
+        Assert.assertNotNull(tableView);
+
+        // initialize was false so set properties and call initialize
+        //Set CornerView to Top Right and ReverseLaout = true
+        tableView.setCornerViewLocation(ITableView.CornerViewLocation.TOP_RIGHT);
+        tableView.setReverseLayout(true);
+        tableView.initialize();
+
+        RelativeLayout rl = new RelativeLayout(InstrumentationRegistry.getInstrumentation().getTargetContext());
+        rl.addView(tableView);
+
+        CornerTestAdapter cornerTestAdapter = new CornerTestAdapter();
+        Assert.assertNotNull(cornerTestAdapter);
+
+        mActivityTestRule.runOnUiThread(() -> tableView.setAdapter(cornerTestAdapter));
+
+        SimpleData simpleData = new SimpleData(5);
+
+        mActivityTestRule.runOnUiThread(() -> cornerTestAdapter.setAllItems(
+                simpleData.getColumnHeaders(), simpleData.getRowHeaders(), simpleData.getCells()));
+
+
+        mActivityTestRule.runOnUiThread(() -> activity.setContentView(rl));
+
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync();
+
+        // Check that the corner view is created
+        // The Corner view uses cell_layout which has LinearLayout as top item
+        RelativeLayout cornerView = (RelativeLayout) tableView.getAdapter().getCornerView();
+        Assert.assertNotNull(cornerView);
+        // Check the corner view is visible
+        Assert.assertEquals(View.VISIBLE, cornerView.getVisibility());
+        // Check that it is the expected corner view by checking the text
+        // The first child of the RelativeLayout is a textView (index starts at zero)
+        TextView cornerViewTextView = (TextView) cornerView.getChildAt(0);
+        Assert.assertEquals("Corner", cornerViewTextView.getText());
+
+        // Check that column headers are ordered Right to Left
+        onView(withText("c:0")).check(isCompletelyRightOf(withText("c:1")));
+
+        // Check that first cell data row are ordered Right to Left
+        onView(withText("r:0c:0")).check(isCompletelyRightOf(withText("r:0c:1")));
+    }
+
+}

--- a/tableview/src/androidTest/res/layout/reverse_layout.xml
+++ b/tableview/src/androidTest/res/layout/reverse_layout.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <com.evrencoskun.tableview.TableView
+        android:id="@+id/tableview"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:corner_view_location="top_right"
+        app:reverse_layout="true">
+
+    </com.evrencoskun.tableview.TableView>
+
+</RelativeLayout>

--- a/tableview/src/main/java/com/evrencoskun/tableview/ITableView.java
+++ b/tableview/src/main/java/com/evrencoskun/tableview/ITableView.java
@@ -186,6 +186,10 @@ public interface ITableView {
 
     int getGravity();
 
+    boolean getReverseLayout();
+
+    void setReverseLayout(boolean reverseLayout);
+
     @Nullable
     AbstractTableAdapter getAdapter();
 

--- a/tableview/src/main/java/com/evrencoskun/tableview/TableView.java
+++ b/tableview/src/main/java/com/evrencoskun/tableview/TableView.java
@@ -121,6 +121,8 @@ public class TableView extends FrameLayout implements ITableView {
 
     private CornerViewLocation mCornerViewLocation;
 
+    private boolean mReverseLayout = false;
+
     public TableView(@NonNull Context context) {
         super(context);
         initialDefaultValues(null);
@@ -166,6 +168,9 @@ public class TableView extends FrameLayout implements ITableView {
         // Cornerview location
         mCornerViewLocation = ITableView.CornerViewLocation.TOP_LEFT;
 
+        // Reverse Layout
+        mReverseLayout = false;
+
         // Colors
         mSelectedColor = ContextCompat.getColor(getContext(), R.color
                 .table_view_default_selected_background_color);
@@ -191,6 +196,9 @@ public class TableView extends FrameLayout implements ITableView {
 
             // CornerView location
             mCornerViewLocation = CornerViewLocation.fromId(a.getInt(R.styleable.TableView_corner_view_location, 0));
+
+            // Reverse Layout
+            mReverseLayout = a.getBoolean(R.styleable.TableView_reverse_layout, mReverseLayout);
 
             // Colors
             mSelectedColor = a.getColor(R.styleable.TableView_selected_color, mSelectedColor);
@@ -309,6 +317,7 @@ public class TableView extends FrameLayout implements ITableView {
         } else {
             layoutParams.leftMargin = mRowHeaderWidth;
         }
+
         recyclerView.setLayoutParams(layoutParams);
 
         if (isShowHorizontalSeparators()) {
@@ -472,6 +481,7 @@ public class TableView extends FrameLayout implements ITableView {
     public ColumnHeaderLayoutManager getColumnHeaderLayoutManager() {
         if (mColumnHeaderLayoutManager == null) {
             mColumnHeaderLayoutManager = new ColumnHeaderLayoutManager(getContext(), this);
+            if (mReverseLayout) mColumnHeaderLayoutManager.setReverseLayout(true);
         }
         return mColumnHeaderLayoutManager;
     }
@@ -874,6 +884,12 @@ public class TableView extends FrameLayout implements ITableView {
                 break;
         }
         return gravity;
+    }
+
+    public boolean getReverseLayout(){ return mReverseLayout;}
+
+    public void setReverseLayout(boolean reverseLayout) {
+        mReverseLayout = reverseLayout;
     }
 
     @Nullable

--- a/tableview/src/main/java/com/evrencoskun/tableview/adapter/recyclerview/CellRecyclerViewAdapter.java
+++ b/tableview/src/main/java/com/evrencoskun/tableview/adapter/recyclerview/CellRecyclerViewAdapter.java
@@ -91,7 +91,9 @@ public class CellRecyclerViewAdapter<C> extends AbstractRecyclerViewAdapter<C> {
         // Set the Column layout manager that helps the fit width of the cell and column header
         // and it also helps to locate the scroll position of the horizontal recyclerView
         // which is row recyclerView
-        recyclerView.setLayoutManager(new ColumnLayoutManager(mContext, mTableView));
+        ColumnLayoutManager mColumnLayoutManager = new ColumnLayoutManager(mContext, mTableView);
+        if (mTableView.getReverseLayout()) mColumnLayoutManager.setReverseLayout(true);
+        recyclerView.setLayoutManager(mColumnLayoutManager);
 
         // Create CellRow adapter
         recyclerView.setAdapter(new CellRowRecyclerViewAdapter<>(mContext, mTableView));

--- a/tableview/src/main/res/values/attrs.xml
+++ b/tableview/src/main/res/values/attrs.xml
@@ -35,5 +35,6 @@
             <enum name="bottom_left" value="2"/>
             <enum name="bottom_right" value="3"/>
         </attr>
+        <attr name="reverse_layout" format="boolean" />
     </declare-styleable>
 </resources>


### PR DESCRIPTION
This Feature enables a user of the library to reverse the Left to Right Header Row and Cell Rows order. 

Thus with the CornerView Location feature a RTL layout can be created like:-

![image](https://user-images.githubusercontent.com/13763054/104967861-4fb6f680-59dc-11eb-8989-30dcd266d79d.png)

To a view like this you would set the attributes
`app:corner_view_location="top_right" `  
`app:reverse_layout="true"`

You can also set this properties programmatically using the 2 part constructor method

This is not automatic RTL support but it allows the user of the library to decide the direction of the layout using the app:reverse_layout attribute
Much like they can do with RecyclerViews (Reverse Layout is actually just passed on to the correct Recycler Views)
It not the business of Library to work out RTL layouts only to support them, much like it is not the Library's Business to correctly RTL the cell contents (That is for the extended TableView Adaptor and user dell layout to do)

Add Instrumented test to cover this reverse layout feature and all Tests Pass
![image](https://user-images.githubusercontent.com/13763054/104968042-c0f6a980-59dc-11eb-9c12-759676f57df5.png)

Off course there needs to be Documentation wiki updates to document these new feature.

Hopeful should cover the follow issues
 RTL support #314 #233 #15 #68
