### PR TITLE
Setup GitHub Actions for tests

### DIFF
--- a/.github/workflows/validate_tableview.yml
+++ b/.github/workflows/validate_tableview.yml
@@ -1,0 +1,67 @@
+name: Validate TableView
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Gradle Wrapper Validation
+        uses: gradle/wrapper-validation-action@v1
+
+      - name: Setup JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+
+      - name: Setup Cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches/
+            ~/.gradle/wrapper/
+          key: cache-gradle-${{ hashFiles('**/*.gradle') }}
+          restore-keys: cache-gradle-
+
+      - name: Build
+        run: ./gradlew :tableview:assembleDebug --no-daemon
+
+  android-tests:
+    name: Android Tests
+    needs: build
+    # Using macos-latest to take advantage of the hardware acceleration
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        api-level: [ 15, 29 ]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+
+      - name: Setup Cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches/
+            ~/.gradle/wrapper/
+          key: cache-gradle-${{ hashFiles('**/*.gradle') }}
+          restore-keys: cache-gradle-
+
+      - name: Android Test - API ${{ matrix.api-level }}
+        uses: ReactiveCircus/android-emulator-runner@v2
+        with:
+          api-level: ${{ matrix.api-level }}
+          script: ./gradlew :tableview:connectedDebugAndroidTest --no-daemon

--- a/.github/workflows/validate_tableview.yml
+++ b/.github/workflows/validate_tableview.yml
@@ -33,6 +33,32 @@ jobs:
       - name: Build
         run: ./gradlew :tableview:assembleDebug --no-daemon
 
+  validate-sample:
+    name: Validate sample app
+    needs: build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+
+      - name: Setup Cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches/
+            ~/.gradle/wrapper/
+          key: cache-gradle-${{ hashFiles('**/*.gradle') }}
+          restore-keys: cache-gradle-
+
+      - name: Build
+        run: ./gradlew :app:assembleDebug --no-daemon
+
   android-tests:
     name: Android Tests
     needs: build


### PR DESCRIPTION
Now that @Zardozz has started to add some tests to the project, it's worth having a CI to ensure that new changes don't break the existing code. 
For the moment, the workflow:
- builds the project
- checks that the sample app still compiles
- runs the tests on emulators:
  - with API 15 (API 14 is not supported by the action I use)
  - with API 29 (the target SDK the project)

A sample output can be seen here: https://github.com/MGaetan89/TableView/actions/runs/497047998

You might have to enable GitHub Actions in the project settings for this to work.