### PR TITLE
Add default get*ItemViewType implementations to AbstractTableAdapter

### DIFF
--- a/tableview/src/androidTest/java/com/evrencoskun/tableview/test/adapters/CornerTestAdapter.java
+++ b/tableview/src/androidTest/java/com/evrencoskun/tableview/test/adapters/CornerTestAdapter.java
@@ -54,7 +54,7 @@ public class CornerTestAdapter extends AbstractTableAdapter<ColumnHeader, RowHea
     }
 
     @NonNull
-    public AbstractViewHolder onCreateCellViewHolder(ViewGroup parent, int viewType) {
+    public AbstractViewHolder onCreateCellViewHolder(@NonNull ViewGroup parent, int viewType) {
         View layout = LayoutInflater.from(parent.getContext())
                 .inflate(R.layout.cell_layout, parent, false);
         return new TestCellViewHolder(layout);
@@ -83,7 +83,8 @@ public class CornerTestAdapter extends AbstractTableAdapter<ColumnHeader, RowHea
     }
 
     @NonNull
-    public AbstractViewHolder onCreateColumnHeaderViewHolder(ViewGroup parent, int viewType) {
+    public AbstractViewHolder onCreateColumnHeaderViewHolder(@NonNull ViewGroup parent, int
+            viewType) {
         View layout = LayoutInflater.from(parent.getContext())
                 .inflate(R.layout.column_layout, parent, false);
         return new TestColumnHeaderViewHolder(layout);
@@ -112,7 +113,7 @@ public class CornerTestAdapter extends AbstractTableAdapter<ColumnHeader, RowHea
     }
 
     @NonNull
-    public AbstractViewHolder onCreateRowHeaderViewHolder(ViewGroup parent, int viewType) {
+    public AbstractViewHolder onCreateRowHeaderViewHolder(@NonNull ViewGroup parent, int viewType) {
         View layout = LayoutInflater.from(parent.getContext())
                 .inflate(R.layout.row_layout, parent, false);
         return new TestRowHeaderViewHolder(layout);
@@ -128,12 +129,8 @@ public class CornerTestAdapter extends AbstractTableAdapter<ColumnHeader, RowHea
     }
 
     @NonNull
-    public View onCreateCornerView(ViewGroup parent) {
+    public View onCreateCornerView(@NonNull ViewGroup parent) {
         return LayoutInflater.from(parent.getContext())
                 .inflate(R.layout.corner_layout, parent, false);
     }
-
-    public int getColumnHeaderItemViewType(int position) { return 0; }
-    public int getRowHeaderItemViewType(int position) { return 0; }
-    public int getCellItemViewType(int position) { return 0; }
 }

--- a/tableview/src/androidTest/java/com/evrencoskun/tableview/test/adapters/SimpleTestAdapter.java
+++ b/tableview/src/androidTest/java/com/evrencoskun/tableview/test/adapters/SimpleTestAdapter.java
@@ -54,7 +54,7 @@ public class SimpleTestAdapter extends AbstractTableAdapter<ColumnHeader, RowHea
     }
 
     @NonNull
-    public AbstractViewHolder onCreateCellViewHolder(ViewGroup parent, int viewType) {
+    public AbstractViewHolder onCreateCellViewHolder(@NonNull ViewGroup parent, int viewType) {
         View layout = LayoutInflater.from(parent.getContext())
                 .inflate(R.layout.cell_layout, parent, false);
         return new TestCellViewHolder(layout);
@@ -71,7 +71,8 @@ public class SimpleTestAdapter extends AbstractTableAdapter<ColumnHeader, RowHea
     }
 
     @NonNull
-    public AbstractViewHolder onCreateColumnHeaderViewHolder(ViewGroup parent, int viewType) {
+    public AbstractViewHolder onCreateColumnHeaderViewHolder(@NonNull ViewGroup parent, int
+            viewType) {
         View layout = LayoutInflater.from(parent.getContext())
                 .inflate(R.layout.cell_layout, parent, false);
         return new TestCellViewHolder(layout);
@@ -89,7 +90,7 @@ public class SimpleTestAdapter extends AbstractTableAdapter<ColumnHeader, RowHea
     }
 
     @NonNull
-    public AbstractViewHolder onCreateRowHeaderViewHolder(ViewGroup parent, int viewType) {
+    public AbstractViewHolder onCreateRowHeaderViewHolder(@NonNull ViewGroup parent, int viewType) {
         View layout = LayoutInflater.from(parent.getContext())
                 .inflate(R.layout.cell_layout, parent, false);
         return new TestCellViewHolder(layout);
@@ -104,12 +105,8 @@ public class SimpleTestAdapter extends AbstractTableAdapter<ColumnHeader, RowHea
     }
 
     @NonNull
-    public View onCreateCornerView(ViewGroup parent) {
+    public View onCreateCornerView(@NonNull ViewGroup parent) {
         return LayoutInflater.from(parent.getContext())
                 .inflate(R.layout.cell_layout, parent, false);
     }
-
-    public int getColumnHeaderItemViewType(int position) { return 0; }
-    public int getRowHeaderItemViewType(int position) { return 0; }
-    public int getCellItemViewType(int position) { return 0; }
 }

--- a/tableview/src/main/java/com/evrencoskun/tableview/adapter/AbstractTableAdapter.java
+++ b/tableview/src/main/java/com/evrencoskun/tableview/adapter/AbstractTableAdapter.java
@@ -159,7 +159,23 @@ public abstract class AbstractTableAdapter<CH, RH, C> implements ITableAdapter<C
         }
     }
 
+    @Override
+    public int getColumnHeaderItemViewType(int position) {
+        return 0;
+    }
+
+    @Override
+    public int getRowHeaderItemViewType(int position) {
+        return 0;
+    }
+
+    @Override
+    public int getCellItemViewType(int position) {
+        return 0;
+    }
+
     @Nullable
+    @Override
     public View getCornerView() {
         return mCornerView;
     }
@@ -357,6 +373,7 @@ public abstract class AbstractTableAdapter<CH, RH, C> implements ITableAdapter<C
      *
      * @param listener The AdapterDataSetChangedListener listener.
      */
+    @Override
     public void addAdapterDataSetChangedListener(@NonNull AdapterDataSetChangedListener<CH, RH, C> listener) {
         if (dataSetChangedListeners == null) {
             dataSetChangedListeners = new ArrayList<>();


### PR DESCRIPTION
This PR adds default implementation of `getColumnHeaderItemViewType`, `getRowHeaderItemViewType` and `getCellItemViewType` to `AbstractTableAdapter`. This replicates the behaviour of `RecyclerView.Adpter`, where `getItemViewType` doesn't need to be overriden if we only have one type.