### PR TITLE
Fix issue #339 - Invalidate column after calling `TableView#setColumnWidth`

### DIFF
--- a/tableview/src/androidTest/java/com/evrencoskun/tableview/TableViewSetColumnWidthTest.java
+++ b/tableview/src/androidTest/java/com/evrencoskun/tableview/TableViewSetColumnWidthTest.java
@@ -1,0 +1,99 @@
+package com.evrencoskun.tableview;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import android.content.Context;
+import android.view.View;
+
+import androidx.annotation.NonNull;
+import androidx.test.ext.junit.rules.ActivityScenarioRule;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.platform.app.InstrumentationRegistry;
+
+import com.evrencoskun.tableview.adapter.recyclerview.CellRecyclerView;
+import com.evrencoskun.tableview.layoutmanager.CellLayoutManager;
+import com.evrencoskun.tableview.layoutmanager.ColumnLayoutManager;
+import com.evrencoskun.tableview.test.TestActivity;
+import com.evrencoskun.tableview.test.adapters.SimpleTestAdapter;
+import com.evrencoskun.tableview.test.data.SimpleData;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(AndroidJUnit4.class)
+public class TableViewSetColumnWidthTest {
+
+    @Rule
+    public ActivityScenarioRule<TestActivity> mActivityRule =
+            new ActivityScenarioRule<>(TestActivity.class);
+
+    private TableView tableView;
+
+    @Before
+    public void before() {
+        Context context = InstrumentationRegistry.getInstrumentation().getContext();
+        SimpleData data = new SimpleData(10);
+        SimpleTestAdapter adapter = new SimpleTestAdapter();
+
+        tableView = new TableView(context);
+        tableView.setAdapter(adapter);
+
+        adapter.setAllItems(data.getColumnHeaders(), data.getRowHeaders(), data.getCells());
+
+        mActivityRule.getScenario()
+                .onActivity(activity -> activity.setContentView(tableView));
+
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync();
+    }
+
+    @Test
+    public void setColumnWidth() {
+        mActivityRule.getScenario()
+                .onActivity(activity -> tableView.setColumnWidth(3, 300));
+
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync();
+
+        validateColumnWidth(tableView, 3, 300);
+    }
+
+    @Test
+    public void setColumnWidthWithHiddenColumn() {
+        mActivityRule.getScenario()
+                .onActivity(activity -> {
+                    tableView.hideColumn(2);
+                    tableView.hideColumn(3);
+                    tableView.setColumnWidth(2, 300);
+                });
+
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync();
+
+        validateColumnWidth(tableView, 2, 300);
+    }
+
+    private void validateColumnWidth(
+            @NonNull TableView tableView,
+            int columnPosition,
+            int expectedWidth
+    ) {
+        View columnHeaderChild = tableView.getColumnHeaderRecyclerView().getChildAt(columnPosition);
+        CellLayoutManager cellLayoutManager = tableView.getCellLayoutManager();
+
+        assertEquals(expectedWidth, columnHeaderChild.getWidth());
+
+        for (int i = cellLayoutManager.findFirstVisibleItemPosition(); i < cellLayoutManager.findLastVisibleItemPosition() + 1; i++) {
+            CellRecyclerView cellRecyclerView = (CellRecyclerView) cellLayoutManager.findViewByPosition(i);
+            assertNotNull(cellRecyclerView);
+
+            ColumnLayoutManager columnLayoutManager = (ColumnLayoutManager) cellRecyclerView.getLayoutManager();
+            assertNotNull(columnLayoutManager);
+
+            View cell = columnLayoutManager.findViewByPosition(columnPosition);
+            assertNotNull(cell);
+
+            assertEquals(expectedWidth, cell.getWidth());
+        }
+    }
+}

--- a/tableview/src/main/java/com/evrencoskun/tableview/handler/ColumnWidthHandler.java
+++ b/tableview/src/main/java/com/evrencoskun/tableview/handler/ColumnWidthHandler.java
@@ -27,6 +27,8 @@ package com.evrencoskun.tableview.handler;
 import androidx.annotation.NonNull;
 
 import com.evrencoskun.tableview.ITableView;
+import com.evrencoskun.tableview.layoutmanager.CellLayoutManager;
+import com.evrencoskun.tableview.layoutmanager.ColumnHeaderLayoutManager;
 
 /**
  * Created by evrencoskun on 25.04.2018.
@@ -43,10 +45,13 @@ public class ColumnWidthHandler {
     public void setColumnWidth(int columnPosition, int width) {
 
         // Firstly set the column header cache map
-        mTableView.getColumnHeaderLayoutManager().setCacheWidth(columnPosition, width);
+        ColumnHeaderLayoutManager columnHeaderLayoutManager = mTableView.getColumnHeaderLayoutManager();
+        columnHeaderLayoutManager.setCacheWidth(columnPosition, width);
+        columnHeaderLayoutManager.customRequestLayout();
 
         // Set each of cell items that is located on the column position
-        mTableView.getCellLayoutManager().setCacheWidth(columnPosition, width);
+        CellLayoutManager cellLayoutManager = mTableView.getCellLayoutManager();
+        cellLayoutManager.setCacheWidth(columnPosition, width);
+        cellLayoutManager.invalidateColumn(columnPosition);
     }
-
 }

--- a/tableview/src/main/java/com/evrencoskun/tableview/layoutmanager/CellLayoutManager.java
+++ b/tableview/src/main/java/com/evrencoskun/tableview/layoutmanager/CellLayoutManager.java
@@ -24,6 +24,8 @@
 
 package com.evrencoskun.tableview.layoutmanager;
 
+import static android.view.ViewGroup.LayoutParams.WRAP_CONTENT;
+
 import android.content.Context;
 import android.os.Handler;
 import android.util.Log;
@@ -41,8 +43,6 @@ import com.evrencoskun.tableview.adapter.recyclerview.CellRecyclerView;
 import com.evrencoskun.tableview.adapter.recyclerview.holder.AbstractViewHolder;
 import com.evrencoskun.tableview.listener.scroll.HorizontalRecyclerViewListener;
 import com.evrencoskun.tableview.util.TableViewUtils;
-
-import static android.view.ViewGroup.LayoutParams.WRAP_CONTENT;
 
 /**
  * Created by evrencoskun on 24/06/2017.
@@ -505,9 +505,43 @@ public class CellLayoutManager extends LinearLayoutManager {
      * Allows to set cache width value for all cell items that is located on column position.
      */
     public void setCacheWidth(int column, int width) {
-        for (int i = 0; i < mRowHeaderRecyclerView.getAdapter().getItemCount(); i++) {
+        RecyclerView.Adapter<?> adapter = mRowHeaderRecyclerView.getAdapter();
+        if (adapter == null) {
+            return;
+        }
+
+        for (int i = 0; i < adapter.getItemCount(); i++) {
             // set cache width for single cell item.
             setCacheWidth(i, column, width);
+        }
+    }
+
+    public void invalidateCell(int row, int column) {
+        int width = getCacheWidth(row, column);
+        if (width == -1) {
+            return;
+        }
+
+        CellRecyclerView cellRecyclerView = (CellRecyclerView) findViewByPosition(row);
+        if (cellRecyclerView != null) {
+            ColumnLayoutManager columnLayoutManager = (ColumnLayoutManager) cellRecyclerView.getLayoutManager();
+            if (columnLayoutManager != null) {
+                View cell = columnLayoutManager.findViewByPosition(column);
+                if (cell != null) {
+                    TableViewUtils.setWidth(cell, width);
+                }
+            }
+        }
+    }
+
+    public void invalidateColumn(int column) {
+        RecyclerView.Adapter<?> adapter = mRowHeaderRecyclerView.getAdapter();
+        if (adapter == null) {
+            return;
+        }
+
+        for (int row = 0; row < adapter.getItemCount(); row++) {
+            invalidateCell(row, column);
         }
     }
 


### PR DESCRIPTION
The current implementation of `TableView#setColumnWidth` only updates the cache, but does not actually update the column, until it has to be redrawn.
This PR fixes that. I didn't find any existing method to invalidate a column, so I added one. Let me know if I missed something, and I'll update my fix accordingly.