### PR TITLE
Add default case

### DIFF
--- a/app/src/main/java/com/evrencoskun/tableviewsample/tableview/popup/ColumnHeaderLongPressPopup.java
+++ b/app/src/main/java/com/evrencoskun/tableviewsample/tableview/popup/ColumnHeaderLongPressPopup.java
@@ -115,6 +115,8 @@ public class ColumnHeaderLongPressPopup extends PopupMenu implements PopupMenu
             case SCROLL_ROW:
                 mTableView.scrollToRowPosition(5);
                 break;
+            default:
+                break;
         }
         return true;
     }

--- a/app/src/main/java/com/evrencoskun/tableviewsample/tableview/popup/RowHeaderLongPressPopup.java
+++ b/app/src/main/java/com/evrencoskun/tableviewsample/tableview/popup/RowHeaderLongPressPopup.java
@@ -97,6 +97,8 @@ public class RowHeaderLongPressPopup extends PopupMenu implements PopupMenu
             case REMOVE_ROW:
                 mTableView.getAdapter().removeRow(mRowPosition);
                 break;
+            default:
+                break;
         }
         return true;
     }


### PR DESCRIPTION
The `onMenuItemClick` function is missing the default case, and a warning will be reported in Android Studio.